### PR TITLE
Disable GitHub OAuth client configuration in local settings

### DIFF
--- a/boot/platform/src/main/resources/application-local.yml
+++ b/boot/platform/src/main/resources/application-local.yml
@@ -26,8 +26,3 @@ spring:
     timeout: 30s
     connect-timeout: 10s
     repositories.enabled: false
-  security.oauth2.client.registration:
-    github:
-      client-id: Iv1.14a97a700a228437
-      client-secret: 94d4fa39efc5677ea75f5dfae533191c00f76f99
-      scope: user


### PR DESCRIPTION
This commit removes the specific GitHub OAuth client registration details from the application's local configuration file. It ensures that the OAuth client for GitHub is not enabled during local development, streamlining authentication processes for testing and development purposes. Additionally, it removes trailing whitespace for a cleaner file ending.