### PR TITLE
Fix code scanning alert no. 1: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/boot/platform/src/main/java/com/plate/boot/commons/utils/ContextUtils.java
+++ b/boot/platform/src/main/java/com/plate/boot/commons/utils/ContextUtils.java
@@ -83,7 +83,7 @@ public final class ContextUtils implements InitializingBean {
 
     static {
         try {
-            MD = MessageDigest.getInstance("MD5");
+            MD = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             throw RestServerException.withMsg("MD5 algorithm not found", e);
         }


### PR DESCRIPTION
Fixes [https://github.com/vnobo/plate/security/code-scanning/1](https://github.com/vnobo/plate/security/code-scanning/1)

To fix the problem, we should replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm such as SHA-256. This involves changing the `MessageDigest.getInstance("MD5")` call to `MessageDigest.getInstance("SHA-256")`. This change ensures that the hashing operations are secure and resistant to collision attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
