### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -4,6 +4,9 @@ on:
     types:
       - closed
 
+permissions:
+  actions: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vnobo/plate/security/code-scanning/2](https://github.com/vnobo/plate/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow (at the root level, above `jobs:`) to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow uses the `gh cache` command, which requires access to repository caches, the minimal required permission is `actions: write`. Other permissions (such as `contents` or `pull-requests`) are not needed for this workflow. The change should be made at the top level of `.github/workflows/cleanup-caches.yml`, above the `jobs:` key, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
