### PR TITLE
feat(ng-plate): implement tenant management module

### DIFF
--- a/ui/ng-plate/src/app/pages/platform/tenant/tenant.html
+++ b/ui/ng-plate/src/app/pages/platform/tenant/tenant.html
@@ -1,7 +1,7 @@
 <div class="page-header d-print-none">
   <div class="row align-items-center">
     <div class="col">
-      <div class="page-pretitle">概览</div>
+      <div class="page-pretitle">系统管理</div>
       <h2 class="page-title">租户管理</h2>
     </div>
     <div class="col-auto ms-auto">
@@ -29,6 +29,7 @@
     </div>
   </div>
 </div>
+
 <div class="page-body">
   @if (isEditing()) {
     <div class="card mb-4">
@@ -64,20 +65,21 @@
 
             <div class="col-md-6">
               <div class="mb-3">
-                <label for="status" class="form-label">状态</label>
+                <label for="pcode" class="form-label">父级租户 *</label>
                 <select
-                  id="status"
+                  id="pcode"
                   class="form-select"
-                  [class.is-invalid]="isFieldInvalid('status')"
-                  [formField]="tenantForm.status"
+                  [class.is-invalid]="isFieldInvalid('pcode')"
+                  [formField]="tenantForm.pcode"
                 >
-                  <option value="active">活跃</option>
-                  <option value="inactive">非活跃</option>
-                  <option value="suspended">已暂停</option>
+                  <option [value]="ROOT_PCODE">根租户（顶级）</option>
+                  @for (p of parents(); track p.code) {
+                    <option [value]="p.code">{{ p.name }}</option>
+                  }
                 </select>
-                @if (isFieldInvalid('status')) {
+                @if (isFieldInvalid('pcode')) {
                   <div class="invalid-feedback">
-                    {{ getFieldError('status') }}
+                    {{ getFieldError('pcode') }}
                   </div>
                 }
               </div>
@@ -100,65 +102,6 @@
             }
           </div>
 
-          <div class="row">
-            <div class="col-md-6">
-              <div class="mb-3">
-                <label for="subscriptionType" class="form-label">订阅类型</label>
-                <select
-                  id="subscriptionType"
-                  class="form-select"
-                  [formField]="tenantForm.subscriptionType"
-                >
-                  <option value="basic">基础版</option>
-                  <option value="standard">标准版</option>
-                  <option value="premium">高级版</option>
-                </select>
-              </div>
-            </div>
-
-            <div class="col-md-6">
-              <div class="mb-3">
-                <label for="expirationDate" class="form-label">过期日期</label>
-                <input
-                  type="date"
-                  id="expirationDate"
-                  class="form-control"
-                  [formField]="tenantForm.expirationDate"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div class="hr-text mb-3">其他信息</div>
-
-          <div class="row">
-            <div class="col-md-6">
-              <div class="mb-3">
-                <label for="createdAt" class="form-label">创建日期</label>
-                <input
-                  type="text"
-                  id="createdAt"
-                  class="form-control"
-                  [value]="currentTenant()?.createdAt | date: 'yyyy-MM-dd HH:mm'"
-                  disabled
-                />
-              </div>
-            </div>
-
-            <div class="col-md-6">
-              <div class="mb-3">
-                <label for="updatedAt" class="form-label">更新日期</label>
-                <input
-                  type="text"
-                  id="updatedAt"
-                  class="form-control"
-                  [value]="currentTenant()?.updatedAt | date: 'yyyy-MM-dd HH:mm'"
-                  disabled
-                />
-              </div>
-            </div>
-          </div>
-
           <div class="form-footer">
             <button type="button" class="btn btn-secondary me-2" (click)="cancelEdit()">
               取消
@@ -171,181 +114,115 @@
       </div>
     </div>
   }
-  <div class="row row-deck">
-    <div class="col-12">
-      <div class="card">
-        <div class="card-header">
-          <h3 class="card-title">租户列表</h3>
-          <div class="card-actions">
-            <div class="input-icon">
-              <input
-                type="text"
-                placeholder="搜索租户..."
-                [value]="searchKeyword()"
-                (input)="onSearchChange($any($event).target.value)"
-                class="form-control"
-              />
-              <span class="input-icon-addon">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="icon"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  stroke-width="2"
-                  stroke="currentColor"
-                  fill="none"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                  <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"></path>
-                  <path d="M21 21l-6 -6"></path>
-                </svg>
-              </span>
-            </div>
-          </div>
-        </div>
-        <div class="table-responsive">
-          <table class="table card-table table-vcenter text-nowrap datatable">
-            <thead>
-              <tr>
-                <th>租户名称</th>
-                <th>描述</th>
-                <th>状态</th>
-                <th>创建日期</th>
-                <th>订阅类型</th>
-                <th>过期日期</th>
-                <th class="w-1">操作</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (tenant of paginatedTenants(); track tenant.id) {
-                <tr>
-                  <td>{{ tenant.name }}</td>
-                  <td>{{ tenant.description || '-' }}</td>
-                  <td>
-                    <span class="badge" [class]="getStatusClass(tenant.status)">
-                      {{ getStatusText(tenant.status) }}
-                    </span>
-                  </td>
-                  <td>{{ tenant.createdAt | date: 'yyyy-MM-dd' }}</td>
-                  <td>{{ tenant.subscriptionType || '-' }}</td>
-                  <td>
-                    {{ tenant.expirationDate ? (tenant.expirationDate | date: 'yyyy-MM-dd') : '-' }}
-                  </td>
-                  <td>
-                    <button
-                      class="btn btn-icon btn-outline-primary me-2"
-                      (click)="editTenant(tenant)"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="icon"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        stroke-width="2"
-                        stroke="currentColor"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      >
-                        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                        <path d="M4 20h4l10.5 -10.5a1.5 1.5 0 0 0 -4 -4l-10.5 10.5v4"></path>
-                        <path d="M13.5 6.5l4 4"></path>
-                      </svg>
-                    </button>
-                    <button
-                      class="btn btn-icon btn-outline-danger"
-                      (click)="deleteTenant(tenant.id)"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="icon"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        stroke-width="2"
-                        stroke="currentColor"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      >
-                        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                        <path d="M4 7l16 0"></path>
-                        <path d="M10 11l0 6"></path>
-                        <path d="M14 11l0 6"></path>
-                        <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"></path>
-                        <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"></path>
-                      </svg>
-                    </button>
-                  </td>
-                </tr>
-              } @empty {
-                <tr>
-                  <td colspan="7" class="text-center text-muted py-4">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="icon mb-2"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      stroke-width="2"
-                      stroke="currentColor"
-                      fill="none"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                      <path d="M12 9v2m0 4v.01"></path>
-                      <path
-                        d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75"
-                      ></path>
-                    </svg>
-                    <div>暂无租户数据</div>
-                    <small class="text-muted">点击上方按钮创建第一个租户</small>
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
-        </div>
 
-        <!-- 分页组件 -->
-        <div class="card-footer d-flex align-items-center">
-          <p class="m-0 text-secondary">
-            显示 {{ (currentPage() - 1) * itemsPerPage() + 1 }} -
-            {{ getMinDate(currentPage() * itemsPerPage(), filteredTenants().length) }} 条，共
-            {{ filteredTenants().length }} 条
-          </p>
-          <ul class="pagination m-0 ms-auto">
-            <li class="page-item" [class.disabled]="currentPage() === 1">
-              <a
-                class="page-link"
-                (click)="changePage(currentPage() - 1)"
-                [class.disabled]="currentPage() === 1"
-                >上一页</a
-              >
-            </li>
-
-            @for (page of getPaginationItems(); track page) {
-              <li class="page-item" [class.active]="page === currentPage()">
-                <a class="page-link" (click)="changePage(page)">{{ page }}</a>
-              </li>
-            }
-
-            <li class="page-item" [class.disabled]="currentPage() === totalPages()">
-              <a
-                class="page-link"
-                (click)="changePage(currentPage() + 1)"
-                [class.disabled]="currentPage() === totalPages()"
-                >下一页</a
-              >
-            </li>
-          </ul>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">租户列表</h3>
+      <div class="card-actions">
+        <div class="input-icon">
+          <input
+            type="text"
+            placeholder="搜索租户名称..."
+            [value]="searchKeyword()"
+            (input)="onSearchChange($any($event).target.value)"
+            class="form-control"
+          />
+          <span class="input-icon-addon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              stroke-width="2"
+              stroke="currentColor"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"></path>
+              <path d="M21 21l-6 -6"></path>
+            </svg>
+          </span>
         </div>
       </div>
+    </div>
+
+    <div class="table-responsive">
+      @if (isLoading()) {
+        <div class="text-center py-4">
+          <div class="spinner-border spinner-border-sm text-muted" role="status">
+            <span class="visually-hidden">加载中...</span>
+          </div>
+          <span class="ms-2 text-muted">加载中...</span>
+        </div>
+      } @else {
+        <table class="table card-table table-vcenter text-nowrap datatable">
+          <thead>
+            <tr>
+              <th>租户名称</th>
+              <th>描述</th>
+              <th>父级租户</th>
+              <th>创建时间</th>
+              <th class="w-1">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (tenant of tenantData().content; track tenant.code) {
+              <tr>
+                <td>{{ tenant.name }}</td>
+                <td>{{ tenant.description || '-' }}</td>
+                <td>{{ parentName(tenant.pcode) }}</td>
+                <td>{{ tenant.createdAt | date: 'yyyy-MM-dd HH:mm' }}</td>
+                <td>
+                  <div class="btn-list flex-nowrap">
+                    <button class="btn btn-outline-primary btn-sm" (click)="editTenant(tenant)">
+                      编辑
+                    </button>
+                    <button class="btn btn-outline-danger btn-sm" (click)="onDelete(tenant)">
+                      删除
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            } @empty {
+              <tr>
+                <td colspan="5" class="text-center text-muted py-4">暂无租户数据</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      }
+    </div>
+
+    <div class="card-footer d-flex align-items-center">
+      <p class="m-0 text-secondary">
+        显示 {{ (pageable().page - 1) * pageable().size + 1 }} -
+        {{ Math.min(pageable().page * pageable().size, tenantData().totalElements || 0) }} 条，共
+        {{ tenantData().totalElements || 0 }} 条
+      </p>
+      <ul class="pagination m-0 ms-auto">
+        <li class="page-item" [class.disabled]="pageable().page <= 1">
+          <a class="page-link" (click)="changePage(pageable().page - 1)">上一页</a>
+        </li>
+
+        @for (page of getPageNumbers(); track $index) {
+          @if (page === -1) {
+            <li class="page-item disabled">
+              <span class="page-link">…</span>
+            </li>
+          } @else {
+            <li class="page-item" [class.active]="page === pageable().page">
+              <a class="page-link" (click)="changePage(page)">{{ page }}</a>
+            </li>
+          }
+        }
+
+        <li class="page-item" [class.disabled]="pageable().page >= getTotalPages()">
+          <a class="page-link" (click)="changePage(pageable().page + 1)">下一页</a>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/ui/ng-plate/src/app/pages/platform/tenant/tenant.ts
+++ b/ui/ng-plate/src/app/pages/platform/tenant/tenant.ts
@@ -1,5 +1,6 @@
 import { DatePipe } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
+import { HttpClient, httpResource } from '@angular/common/http';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import {
   FieldState,
   FormField,
@@ -9,18 +10,14 @@ import {
   required,
   submit,
 } from '@angular/forms/signals';
-import { Router } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
 
-export interface Tenant {
-  id: string;
-  name: string;
-  description?: string;
-  status: 'active' | 'inactive' | 'suspended';
-  createdAt: Date;
-  updatedAt: Date;
-  subscriptionType?: string;
-  expirationDate?: Date;
-}
+import { MessageService } from '@app/plugins';
+import { Page, Pageable } from '@plate/types';
+import { environment } from '@envs/env';
+
+import { ROOT_PCODE, Tenant } from './tenant.types';
 
 @Component({
   selector: 'app-tenant',
@@ -29,85 +26,117 @@ export interface Tenant {
   styleUrl: './tenant.scss',
 })
 export class Tenants {
-  protected readonly tenants = signal<Tenant[]>([
-    {
-      id: '1',
-      name: '示例租户1',
-      description: '这是一个示例租户1',
-      status: 'active',
-      createdAt: new Date('2023-01-15'),
-      updatedAt: new Date('2023-10-20'),
-      subscriptionType: 'premium',
-      expirationDate: new Date('2024-01-15'),
-    },
-    {
-      id: '2',
-      name: '示例租户2',
-      description: '这是一个示例租户2',
-      status: 'inactive',
-      createdAt: new Date('2023-03-02'),
-      updatedAt: new Date('2023-09-10'),
-      subscriptionType: 'standard',
-      expirationDate: new Date('2023-12-31'),
-    },
-    {
-      id: '3',
-      name: '示例租户3',
-      description: '这是一个示例租户3',
-      status: 'suspended',
-      createdAt: new Date('2023-05-30'),
-      updatedAt: new Date('2023-11-05'),
-      subscriptionType: 'premium',
-      expirationDate: new Date('2024-02-28'),
-    },
-  ]);
+  private readonly _message = inject(MessageService);
+  private readonly _http = inject(HttpClient);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  protected readonly currentPage = signal(1);
-  protected readonly itemsPerPage = signal(5);
-  protected readonly totalPages = computed(() =>
-    Math.ceil(this.filteredTenants().length / this.itemsPerPage()),
-  );
+  protected readonly ROOT_PCODE = ROOT_PCODE;
 
-  protected readonly paginatedTenants = computed(() => {
-    const start = (this.currentPage() - 1) * this.itemsPerPage();
-    const end = start + this.itemsPerPage();
-    return this.filteredTenants().slice(start, end);
+  pageable = signal<Pageable>({
+    page: 1,
+    size: 10,
+    sorts: ['id,desc'],
   });
 
+  /** 名称关键字（后端按 name 模糊匹配） */
   protected readonly searchKeyword = signal('');
 
-  protected readonly filteredTenants = computed(() => {
-    const keyword = this.searchKeyword().toLowerCase();
-    return this.tenants().filter(
-      (tenant) =>
-        tenant.name.toLowerCase().includes(keyword) ||
-        (tenant.description && tenant.description.toLowerCase().includes(keyword)),
-    );
-  });
-
-  protected readonly currentTenant = signal<Tenant | null>(null);
-
-  protected readonly isEditing = signal(false);
-
-  private readonly router = inject(Router);
-
-  private readonly initialFormModel = {
-    name: '',
-    description: '',
-    status: 'active' as 'active' | 'inactive' | 'suspended',
-    subscriptionType: 'standard' as 'basic' | 'standard' | 'premium',
-    expirationDate: null as Date | null,
+  private readonly emptyPage: Page<Tenant> = {
+    content: [],
+    pageable: { page: 0, size: 0, sorts: [] },
+    totalElements: 0,
+    totalPages: 0,
+    size: 0,
+    number: 0,
+    first: true,
+    last: true,
+    numberOfElements: 0,
+    empty: true,
   };
 
-  protected readonly tenantModel = signal({ ...this.initialFormModel });
+  protected readonly tenantResource = httpResource<Page<Tenant>>(
+    () => {
+      const page = this.pageable();
+      const keyword = this.searchKeyword().trim();
+      const params: Record<
+        string,
+        string | number | boolean | ReadonlyArray<string | number | boolean>
+      > = {
+        page: page.page - 1,
+        size: page.size,
+      };
+      if (keyword) {
+        params['name'] = keyword;
+      }
+      for (const sort of page.sorts) {
+        if (!params['sort']) {
+          params['sort'] = [sort];
+        } else if (Array.isArray(params['sort'])) {
+          (params['sort'] as string[]).push(sort);
+        }
+      }
+      return {
+        url: environment.secApiPath + '/tenants/page',
+        params,
+      };
+    },
+    {
+      defaultValue: this.emptyPage,
+      debugName: 'tenants-page',
+    },
+  );
+
+  /** 全部租户（用于父级下拉与名称解析） */
+  protected readonly parentResource = httpResource<Tenant[]>(
+    () => ({
+      url: environment.secApiPath + '/tenants/search',
+      params: { size: 1000 },
+    }),
+    {
+      defaultValue: [],
+      debugName: 'tenants-parent',
+    },
+  );
+
+  protected readonly tenantData = computed(() => this.tenantResource.value());
+  protected readonly isLoading = computed(() => this.tenantResource.isLoading());
+  protected readonly parents = computed(() => this.parentResource.value() ?? []);
+
+  protected readonly parentNameMap = computed(() => {
+    const map = new Map<string, string>();
+    for (const t of this.parents()) {
+      if (t.code) {
+        map.set(t.code, t.name ?? t.code);
+      }
+    }
+    return map;
+  });
+
+  protected parentName(code?: string): string {
+    if (!code) return '-';
+    if (code === ROOT_PCODE) return '根租户';
+    return this.parentNameMap().get(code) ?? code;
+  }
+
+  protected readonly Math = Math;
+
+  protected readonly isEditing = signal(false);
+  protected readonly currentTenant = signal<Tenant | null>(null);
+
+  private readonly initialModel = {
+    name: '',
+    description: '',
+    pcode: ROOT_PCODE,
+  };
+
+  protected readonly tenantModel = signal({ ...this.initialModel });
 
   protected readonly tenantForm = form(this.tenantModel, (p) => {
     required(p.name, { message: '租户名称 是必填项' });
     minLength(p.name, 2, { message: '租户名称 至少需要 2 个字符' });
     maxLength(p.name, 50, { message: '租户名称 不能超过 50 个字符' });
     maxLength(p.description, 500, { message: '描述 不能超过 500 个字符' });
-    required(p.status, { message: '状态 是必填项' });
-    required(p.subscriptionType, { message: '订阅类型 是必填项' });
+    required(p.pcode, { message: '父级租户 是必填项' });
   });
 
   protected getFieldError(fieldName: string): string {
@@ -132,146 +161,127 @@ export class Tenants {
     return fieldState.invalid() && fieldState.touched();
   }
 
-  editTenant(tenant: Tenant) {
+  protected createTenant(): void {
+    this.currentTenant.set(null);
+    this.tenantModel.set({ ...this.initialModel });
+    this.isEditing.set(true);
+  }
+
+  protected editTenant(tenant: Tenant): void {
     this.currentTenant.set(tenant);
     this.tenantModel.set({
-      name: tenant.name,
-      description: tenant.description || '',
-      status: tenant.status,
-      subscriptionType: (tenant.subscriptionType ?? 'standard') as 'basic' | 'standard' | 'premium',
-      expirationDate: tenant.expirationDate || null,
+      name: tenant.name ?? '',
+      description: tenant.description ?? '',
+      pcode: tenant.pcode ?? ROOT_PCODE,
     });
     this.isEditing.set(true);
   }
 
-  createTenant() {
+  protected cancelEdit(): void {
+    this.isEditing.set(false);
     this.currentTenant.set(null);
-    this.tenantModel.set({ ...this.initialFormModel });
-    this.isEditing.set(true);
+    this.tenantModel.set({ ...this.initialModel });
   }
 
-  async saveTenant() {
+  protected async saveTenant(): Promise<void> {
     await submit(this.tenantForm, {
       action: async () => {
-        const formData = this.tenantModel();
-
-        if (this.currentTenant()) {
-          this.tenants.update((tenants) =>
-            tenants.map((tenant) =>
-              tenant.id === this.currentTenant()?.id
-                ? ({
-                    ...tenant,
-                    name: formData.name ?? tenant.name,
-                    description: formData.description ?? tenant.description,
-                    status:
-                      (formData.status as 'active' | 'inactive' | 'suspended') ?? tenant.status,
-                    subscriptionType: formData.subscriptionType ?? tenant.subscriptionType,
-                    expirationDate: formData.expirationDate ?? tenant.expirationDate,
-                    updatedAt: new Date(),
-                  } as Tenant)
-                : tenant,
-            ),
-          );
-        } else {
-          const newTenant: Tenant = {
-            id: (Math.max(...this.tenants().map((t) => parseInt(t.id) || 0), 0) + 1).toString(),
-            name: formData.name ?? '',
-            description: formData.description ?? '',
-            status: (formData.status as 'active' | 'inactive' | 'suspended') ?? 'active',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-            subscriptionType: formData.subscriptionType ?? undefined,
-            expirationDate: formData.expirationDate ?? undefined,
-          };
-          this.tenants.update((tenants) => [...tenants, newTenant]);
+        const model = this.tenantModel();
+        const current = this.currentTenant();
+        const payload: Tenant = {
+          name: model.name,
+          description: model.description,
+          pcode: model.pcode,
+        };
+        if (current?.code) {
+          payload.id = current.id;
+          payload.code = current.code;
         }
 
-        this.isEditing.set(false);
-        this.currentTenant.set(null);
-        this.tenantModel.set({ ...this.initialFormModel });
+        const request = current?.code
+          ? this._http.put<Tenant>(environment.secApiPath + '/tenants/save', payload)
+          : this._http.post<Tenant>(environment.secApiPath + '/tenants/save', payload);
+
+        request
+          .pipe(
+            tap(() => this._message.success(current?.code ? '租户已更新' : '租户已创建')),
+            delay(800),
+            takeUntilDestroyed(this._destroyRef),
+          )
+          .subscribe(() => {
+            this.cancelEdit();
+            this.tenantResource.reload();
+            this.parentResource.reload();
+          });
       },
     });
   }
 
-  deleteTenant(id: string) {
-    if (confirm('确定要删除这个租户吗？此操作不可撤销。')) {
-      this.tenants.update((tenants) => tenants.filter((tenant) => tenant.id !== id));
-      if (this.paginatedTenants().length === 0 && this.currentPage() > 1) {
-        this.currentPage.update((page) => page - 1);
-      }
+  protected onDelete(tenant: Tenant): void {
+    if (!tenant.code || tenant.id == null) {
+      return;
     }
+    if (!confirm(`确定要删除租户「${tenant.name ?? tenant.code}」吗？此操作不可撤销。`)) {
+      return;
+    }
+    this._http
+      .delete<void>(environment.secApiPath + '/tenants/delete', {
+        body: { id: tenant.id, code: tenant.code },
+      })
+      .pipe(
+        tap(() => this._message.success('租户已删除')),
+        delay(800),
+        takeUntilDestroyed(this._destroyRef),
+      )
+      .subscribe(() => {
+        this.tenantResource.reload();
+        this.parentResource.reload();
+      });
   }
 
-  cancelEdit() {
-    this.isEditing.set(false);
-    this.currentTenant.set(null);
-    this.tenantModel.set({ ...this.initialFormModel });
-  }
-
-  onSearchChange(value: string) {
+  protected onSearchChange(value: string): void {
     this.searchKeyword.set(value);
-    this.currentPage.set(1);
+    this.pageable.update((p) => ({ ...p, page: 1 }));
   }
 
-  getStatusText(status: 'active' | 'inactive' | 'suspended'): string {
-    switch (status) {
-      case 'active':
-        return '活跃';
-      case 'inactive':
-        return '非活跃';
-      case 'suspended':
-        return '已暂停';
-      default:
-        return status;
+  protected changePage(page: number): void {
+    if (page < 1 || page > this.getTotalPages()) {
+      return;
     }
+    this.pageable.update((p) => ({ ...p, page }));
   }
 
-  getStatusClass(status: 'active' | 'inactive' | 'suspended'): string {
-    switch (status) {
-      case 'active':
-        return 'badge bg-success';
-      case 'inactive':
-        return 'badge bg-secondary';
-      case 'suspended':
-        return 'badge bg-warning';
-      default:
-        return 'badge bg-secondary';
+  protected getTotalPages(): number {
+    const totalElements = this.tenantData().totalElements || 0;
+    return Math.ceil(totalElements / this.pageable().size);
+  }
+
+  protected getPageNumbers(): number[] {
+    const totalPages = this.getTotalPages();
+    const currentPage = this.pageable().page;
+    const pages: number[] = [];
+
+    if (totalPages >= 1) {
+      pages.push(1);
     }
-  }
-
-  changePage(page: number): void {
-    if (page >= 1 && page <= this.totalPages()) {
-      this.currentPage.set(page);
+    if (currentPage > 3) {
+      pages.push(-1);
     }
-  }
-
-  getPaginationItems(): number[] {
-    const total = this.totalPages();
-    const current = this.currentPage();
-    const items: number[] = [];
-
-    if (total <= 7) {
-      for (let i = 1; i <= total; i++) {
-        items.push(i);
+    for (
+      let i = Math.max(2, currentPage - 1);
+      i <= Math.min(totalPages - 1, currentPage + 1);
+      i++
+    ) {
+      if (i > 1 && i < totalPages) {
+        pages.push(i);
       }
-    } else {
-      items.push(1);
-      if (current > 4) {
-        items.push(-1);
-      }
-      for (let i = Math.max(2, current - 2); i <= Math.min(total - 1, current + 2); i++) {
-        items.push(i);
-      }
-      if (current < total - 3) {
-        items.push(-1);
-      }
-      items.push(total);
     }
-
-    return items;
-  }
-
-  getMinDate(value1: number, value2: number): number {
-    return Math.min(value1, value2);
+    if (currentPage < totalPages - 2) {
+      pages.push(-1);
+    }
+    if (totalPages > 1) {
+      pages.push(totalPages);
+    }
+    return pages;
   }
 }

--- a/ui/ng-plate/src/app/pages/platform/tenant/tenant.types.ts
+++ b/ui/ng-plate/src/app/pages/platform/tenant/tenant.types.ts
@@ -1,0 +1,19 @@
+import { Search, UserAuditor } from '@plate/types';
+
+export interface Tenant extends Search {
+  id?: number;
+  code?: string;
+  pcode?: string;
+  tenantCode?: string;
+  name?: string;
+  description?: string;
+  createdBy?: UserAuditor;
+  updatedBy?: UserAuditor;
+  createdAt?: string;
+  updatedAt?: string;
+  version?: number;
+  extend?: Record<string, unknown>;
+}
+
+/** 顶级（根）租户的父级编码，对应数据库 se_tenants.pcode 列的默认值 */
+export const ROOT_PCODE = '00000000-0000-0000-0000-000000000000';


### PR DESCRIPTION
Replace the mock tenant page with a real CRUD module following the users.ts convention.

- List tenants via httpResource (/sec/tenants/page)
- Create/update via /sec/tenants/save
- Delete via /sec/tenants/delete
- Align Tenant model to backend entity (pcode/name/description)
- Parent-tenant selection defaulting to the root zero UUID
- Name search + pagination