### PR TITLE
fix(ng-plate): make user management module functional

### DIFF
--- a/ui/ng-plate/src/app/pages/dashboard/users/user-form.ts
+++ b/ui/ng-plate/src/app/pages/dashboard/users/user-form.ts
@@ -1,14 +1,20 @@
 import {
   Component,
   computed,
+  DestroyRef,
   effect,
+  inject,
   input,
   linkedSignal,
-  output,
   signal,
 } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { FormField, form, email, required, submit, disabled } from '@angular/forms/signals';
+import { MessageService } from '@app/plugins';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
 import { User } from './user.types';
+import { environment } from '@envs/env';
 
 @Component({
   selector: 'app-user-form',
@@ -132,7 +138,10 @@ export class UserForm {
 
   private readonly userData = linkedSignal(this.inputData);
   readonly created = computed(() => this.userData()?.code == undefined);
-  formSubmit = output<User>();
+
+  private readonly _http = inject(HttpClient);
+  private readonly _message = inject(MessageService);
+  private readonly _destroyRef = inject(DestroyRef);
 
   isSubmitting = signal(false);
   passwordError = signal('');
@@ -207,13 +216,35 @@ export class UserForm {
     await submit(this.userForm, {
       action: async () => {
         const model = this.userModel();
-        const result: User = {
-          ...model,
-        } as User;
-        this.formSubmit.emit(result);
+        const result: User = { ...model } as User;
+        // 编辑时不提交密码，避免误改密码
+        if (!this.created()) {
+          delete (result as Record<string, unknown>)['password'];
+          delete (result as Record<string, unknown>)['confirmPassword'];
+        }
+        const request = this.created()
+          ? this._http.post<User>(environment.secApiPath + '/users/add', result)
+          : this._http.put<User>(environment.secApiPath + '/users/modify', result);
+        request
+          .pipe(
+            tap(() =>
+              this._message.success(this.created() ? '用户创建成功' : '用户更新成功'),
+            ),
+            delay(800),
+            takeUntilDestroyed(this._destroyRef),
+          )
+          .subscribe(() => this.closeModal());
       },
     });
     this.isSubmitting.set(false);
+  }
+
+  private closeModal() {
+    const el = document.getElementById('exampleModal');
+    if (el) {
+      const instance = tabler?.Modal?.getOrCreateInstance(el);
+      instance?.hide();
+    }
   }
 
   resetForm() {

--- a/ui/ng-plate/src/app/pages/dashboard/users/users.ts
+++ b/ui/ng-plate/src/app/pages/dashboard/users/users.ts
@@ -1,14 +1,15 @@
-import { Component, computed, inject, inputBinding, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { delay, tap } from 'rxjs';
 
 import { DatePipe } from '@angular/common';
 import { HttpClient, httpResource } from '@angular/common/http';
+import { DestroyRef } from '@angular/core';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MessageService, ModalsService } from '@app/plugins';
 import { Page, Pageable } from '@plate/types';
 import { UserForm } from './user-form';
 import { User } from './user.types';
 import { environment } from '@envs/env';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-users',
@@ -20,6 +21,7 @@ export class Users {
   private readonly _message = inject(MessageService);
   private readonly _modal = inject(ModalsService);
   private readonly _http = inject(HttpClient);
+  private readonly _destroyRef = inject(DestroyRef);
 
   pageable = signal<Pageable>({
     page: 1,
@@ -86,10 +88,7 @@ export class Users {
   Math = Math;
 
   openModal() {
-    this._modal.create({
-      title: '用户表单',
-      contentRef: UserForm,
-    });
+    this.openUserForm({} as User);
   }
 
   fetchUserData() {
@@ -99,13 +98,14 @@ export class Users {
   onTableQueryChange($event: Pageable) {}
 
   openUserForm(user: User) {
-    const userSignal = signal(user);
-
-    this._modal.create({
+    const ref = this._modal.create({
       title: user.id ? '编辑用户' : '添加用户',
       contentRef: UserForm,
-      contentBindings: [inputBinding('inputData', userSignal)],
+      contentInputs: { inputData: user },
     });
+    outputToObservable(ref.instance.dropped)
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this.fetchUserData());
   }
 
   onDelete(user: User) {
@@ -113,7 +113,7 @@ export class Users {
       .pipe(
         tap(() => this._message.success('删除成功!')),
         delay(1500),
-        takeUntilDestroyed(),
+        takeUntilDestroyed(this._destroyRef),
       )
       .subscribe(() => this.fetchUserData());
   }

--- a/ui/ng-plate/src/app/plugins/modals.ts
+++ b/ui/ng-plate/src/app/plugins/modals.ts
@@ -27,6 +27,8 @@ export interface ModalRef {
   headerRef?: Type<unknown> | null;
   contentRef?: Type<unknown> | null;
   footerRef?: Type<unknown> | null;
+  /** Static inputs forwarded to the content component via NgComponentOutletInputs. */
+  contentInputs?: Record<string, unknown>;
   contentBindings?: Binding[];
 }
 
@@ -47,9 +49,6 @@ export class ModalsService {
   create(modalRef: ModalRef) {
     const modalRefSignal = signal(modalRef);
     const bindings = [inputBinding('modalRef', modalRefSignal)];
-    if (modalRef.contentBindings) {
-      bindings.push(...modalRef.contentBindings);
-    }
 
     this.modalRef = createComponent(Modals, {
       environmentInjector: this.injector,
@@ -106,7 +105,9 @@ export class TablerModalsInit {
           </div>
           @if (modalRef().contentRef) {
             <div class="modal-body">
-              <ng-container *ngComponentOutlet="modalRef().contentRef!" />
+              <ng-container
+                *ngComponentOutlet="modalRef().contentRef!; inputs: modalRef().contentInputs || {}"
+              />
             </div>
           }
           @if (modalRef().footerRef) {


### PR DESCRIPTION
修复用户管理模块无法真正保存的问题。

问题根因：共享的 ModalsService 从未把 input 绑定转发给 NgComponentOutlet，导致表单的 inputData 收不到（编辑无法回填），且 NgComponentOutlet 不支持 outputs，formSubmit 永远无法被父组件接收，保存实际不生效。

改动：
- modals.ts：将 contentInputs 转发到 ngComponentOutletInputs，使表单能收到 inputData
- users.ts：以 contentInputs 打开弹窗，弹窗关闭时刷新列表；修复 onDelete 在注入上下文外使用 takeUntilDestroyed 的隐患
- user-form.ts：改为自包含，调用 /sec/users/add 或 /sec/users/modify，成功后提示并关闭弹窗.