### PR TITLE
feat(ng-plate): add role management module

### DIFF
--- a/ui/ng-plate/src/app/layout/layout-aside.ts
+++ b/ui/ng-plate/src/app/layout/layout-aside.ts
@@ -35,6 +35,29 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
                       <span class="nav-link-title">租户管理</span>
                     </a>
                   </li>
+                  <li class="nav-item">
+                    <a class="nav-link" routerLink="./role" routerLinkActive="active">
+                      <span class="nav-link-icon d-md-none d-lg-inline-block">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="24"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="icon icon-1"
+                        >
+                          <path
+                            d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3"
+                          ></path>
+                        </svg>
+                      </span>
+                      <span class="nav-link-title">角色管理</span>
+                    </a>
+                  </li>
                 </ul>
               </div>
               <div class="col col-md-auto"></div>

--- a/ui/ng-plate/src/app/pages/platform/platform.ts
+++ b/ui/ng-plate/src/app/pages/platform/platform.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { BaseLayout } from '@app/layout';
 import { Tenants } from './tenant/tenant';
+import { Role } from './role/role';
 
 export const PLATFORM_ROUTES: Routes = [
   {
@@ -12,6 +13,11 @@ export const PLATFORM_ROUTES: Routes = [
         path: 'tenant',
         component: Tenants,
         title: '租户管理',
+      },
+      {
+        path: 'role',
+        component: Role,
+        title: '角色管理',
       },
       {
         path: '',

--- a/ui/ng-plate/src/app/pages/platform/role/authority-form.ts
+++ b/ui/ng-plate/src/app/pages/platform/role/authority-form.ts
@@ -1,0 +1,119 @@
+import { Component, DestroyRef, computed, effect, inject, input, linkedSignal, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { FormField, form, required, submit } from '@angular/forms/signals';
+import { MessageService } from '@app/plugins';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
+import { GroupAuthority } from './role.types';
+import { environment } from '@envs/env';
+
+@Component({
+  selector: 'app-authority-form',
+  imports: [FormField],
+  template: `
+    <div class="container-fluid">
+      <form (ngSubmit)="onSubmit()" class="form-wrapper">
+        <div class="mb-3">
+          <label class="form-label" for="authority">权限标识 *</label>
+          <input class="form-control" type="text" id="authority" [formField]="authorityForm.authority" />
+          <div class="form-hint">
+            例如 <code>USER_VIEW</code>、<code>ROLE_EDIT</code>，用于标识该角色拥有的操作权限。
+          </div>
+        </div>
+        <div class="d-flex">
+          <button
+            class="btn btn-primary ms-auto"
+            type="submit"
+            [disabled]="!authorityForm().valid() || isSubmitting()"
+          >
+            保存权限
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        min-height: 100%;
+        min-width: 100%;
+      }
+    `,
+  ],
+})
+export class AuthorityForm {
+  /** 当前所属角色编码 */
+  groupCode = input.required<string>();
+  /** 编辑时传入已有权限，新建时为 null */
+  inputData = input<GroupAuthority | null>(null);
+
+  private readonly data = linkedSignal(this.inputData);
+  readonly created = computed(() => this.data()?.code == undefined);
+
+  private readonly _http = inject(HttpClient);
+  private readonly _message = inject(MessageService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  isSubmitting = signal(false);
+
+  private readonly initialModel = {
+    id: undefined as number | undefined,
+    code: '',
+    authority: '',
+  };
+
+  protected readonly model = signal({ ...this.initialModel });
+
+  protected readonly authorityForm = form(this.model, (p) => {
+    required(p.authority, { message: '权限标识 是必填项' });
+  });
+
+  constructor() {
+    effect(() => {
+      const d = this.data();
+      if (this.created()) {
+        this.model.set({ ...this.initialModel });
+      } else if (d) {
+        this.model.set({
+          ...this.initialModel,
+          id: d.id,
+          code: d.code ?? '',
+          authority: d.authority ?? '',
+        });
+      }
+    });
+  }
+
+  async onSubmit() {
+    this.isSubmitting.set(true);
+    await submit(this.authorityForm, {
+      action: async () => {
+        const m = this.model();
+        const payload: GroupAuthority = {
+          authority: m.authority,
+          groupCode: this.groupCode(),
+        };
+        if (!this.created()) {
+          payload.id = m.id;
+          payload.code = m.code;
+        }
+        this._http
+          .post<GroupAuthority>(environment.secApiPath + '/groups/authorities/save', payload)
+          .pipe(
+            tap(() => this._message.success(this.created() ? '权限已添加' : '权限已更新')),
+            delay(800),
+            takeUntilDestroyed(this._destroyRef),
+          )
+          .subscribe(() => this.closeModal());
+      },
+    });
+    this.isSubmitting.set(false);
+  }
+
+  private closeModal() {
+    const el = document.getElementById('exampleModal');
+    if (el) {
+      tabler?.Modal?.getOrCreateInstance(el)?.hide();
+    }
+  }
+}

--- a/ui/ng-plate/src/app/pages/platform/role/member-form.ts
+++ b/ui/ng-plate/src/app/pages/platform/role/member-form.ts
@@ -1,0 +1,114 @@
+import { Component, DestroyRef, computed, inject, input, signal } from '@angular/core';
+import { HttpClient, httpResource } from '@angular/common/http';
+import { FormField, form, required, submit } from '@angular/forms/signals';
+import { MessageService } from '@app/plugins';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
+import { GroupMember } from './role.types';
+import { User } from '../../dashboard/users/user.types';
+import { environment } from '@envs/env';
+
+@Component({
+  selector: 'app-member-form',
+  imports: [FormField],
+  template: `
+    <div class="container-fluid">
+      <form (ngSubmit)="onSubmit()" class="form-wrapper">
+        @if (usersResource.isLoading()) {
+          <div class="text-center py-2 text-muted">加载用户列表中...</div>
+        }
+        <div class="mb-3">
+          <label class="form-label" for="userCode">选择用户 *</label>
+          <select class="form-select" id="userCode" [formField]="memberForm.userCode">
+            <option value="">— 请选择 —</option>
+            @for (u of users(); track u.code) {
+              <option [value]="u.code">
+                {{ u.name || u.username }}<ng-container> ({{ u.username }})</ng-container>
+              </option>
+            }
+          </select>
+        </div>
+        <div class="d-flex">
+          <button
+            class="btn btn-primary ms-auto"
+            type="submit"
+            [disabled]="!memberForm().valid() || isSubmitting()"
+          >
+            添加成员
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        min-height: 100%;
+        min-width: 100%;
+      }
+    `,
+  ],
+})
+export class MemberForm {
+  /** 当前所属角色编码 */
+  groupCode = input.required<string>();
+
+  private readonly _http = inject(HttpClient);
+  private readonly _message = inject(MessageService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  isSubmitting = signal(false);
+
+  /** 可选用户列表（用于下拉选择） */
+  protected readonly usersResource = httpResource<User[]>(
+    () => ({
+      url: environment.secApiPath + '/users/search',
+      params: { size: 1000 },
+    }),
+    { defaultValue: [], debugName: 'member-users' },
+  );
+  protected readonly users = computed(() => this.usersResource.value() ?? []);
+
+  private readonly initialModel = { userCode: '' };
+  protected readonly model = signal({ ...this.initialModel });
+
+  protected readonly memberForm = form(this.model, (p) => {
+    required(p.userCode, { message: '请选择用户' });
+  });
+
+  async onSubmit() {
+    this.isSubmitting.set(true);
+    await submit(this.memberForm, {
+      action: async () => {
+        const payload: GroupMember = {
+          groupCode: this.groupCode(),
+          userCode: this.model().userCode,
+        };
+        this._http
+          .post<GroupMember>(environment.secApiPath + '/groups/members/save', payload)
+          .pipe(
+            tap(() =>
+              this._message.success(
+                `已将用户 ${this.userName(this.model().userCode)} 加入该角色`,
+              ),
+            ),
+            delay(800),
+            takeUntilDestroyed(this._destroyRef),
+          )
+          .subscribe(() => this.closeModal());
+      },
+    });
+    this.isSubmitting.set(false);
+  }
+
+  private userName(code: string): string {
+    return this.users().find((u) => u.code === code)?.name ?? code;
+  }
+
+  private closeModal() {
+    const el = document.getElementById('exampleModal');
+    if (el) {
+      tabler?.Modal?.getOrCreateInstance(el)?.hide();
+    }
+  }
+}

--- a/ui/ng-plate/src/app/pages/platform/role/role-form.ts
+++ b/ui/ng-plate/src/app/pages/platform/role/role-form.ts
@@ -1,0 +1,168 @@
+import {
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  input,
+  linkedSignal,
+  signal,
+} from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { FormField, form, required, submit } from '@angular/forms/signals';
+import { MessageService } from '@app/plugins';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
+import { Group, ROOT_PCODE } from './role.types';
+import { environment } from '@envs/env';
+
+@Component({
+  selector: 'app-role-form',
+  imports: [FormField],
+  template: `
+    <div class="container-fluid">
+      <form (ngSubmit)="onSubmit()" class="form-wrapper">
+        <div class="mb-3">
+          <label class="form-label" for="name">角色名称 *</label>
+          <input class="form-control" type="text" id="name" [formField]="roleForm.name" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="pcode">父级角色</label>
+          <select class="form-select" id="pcode" [formField]="roleForm.pcode">
+            <option [value]="ROOT_PCODE">根角色（顶级）</option>
+            @for (p of parentOptions(); track p.code) {
+              <option [value]="p.code">{{ p.name }}</option>
+            }
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="description">描述</label>
+          <textarea class="form-control" type="text" id="description" rows="3" [formField]="roleForm.description"></textarea>
+        </div>
+        <div class="d-flex">
+          <button class="btn btn-primary ms-auto" type="submit" [disabled]="!roleForm().valid() || isSubmitting()">
+            保存角色
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        min-height: 100%;
+        min-width: 100%;
+      }
+    `,
+  ],
+})
+export class RoleForm {
+  inputData = input<Group | null>(null);
+  allGroups = input<Group[]>([]);
+
+  private readonly userData = linkedSignal(this.inputData);
+  readonly created = computed(() => this.userData()?.code == undefined);
+
+  private readonly _http = inject(HttpClient);
+  private readonly _message = inject(MessageService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  protected readonly ROOT_PCODE = ROOT_PCODE;
+
+  isSubmitting = signal(false);
+
+  private readonly initialModel = {
+    id: undefined as number | undefined,
+    code: '',
+    pcode: ROOT_PCODE,
+    name: '',
+    description: '',
+  };
+
+  protected readonly roleModel = signal({ ...this.initialModel });
+
+  protected readonly roleForm = form(this.roleModel, (p) => {
+    required(p.name, { message: '角色名称 是必填项' });
+    required(p.pcode, { message: '父级角色 是必填项' });
+  });
+
+  /** 可选父级 = 除自身及其后代之外的所有角色（避免循环） */
+  parentOptions = computed(() => {
+    const data = this.userData();
+    const selfCode = data?.code;
+    const excluded = selfCode ? this.descendantsOf(selfCode) : new Set<string>();
+    return this.allGroups().filter((g) => g.code && !excluded.has(g.code));
+  });
+
+  constructor() {
+    effect(() => {
+      const data = this.userData();
+      if (this.created()) {
+        this.roleModel.set({
+          ...this.initialModel,
+          pcode: data?.pcode ?? ROOT_PCODE,
+        });
+      } else if (data) {
+        this.roleModel.set({
+          ...this.initialModel,
+          id: data.id,
+          code: data.code ?? '',
+          pcode: data.pcode ?? ROOT_PCODE,
+          name: data.name ?? '',
+          description: data.description ?? '',
+        });
+      }
+    });
+  }
+
+  private descendantsOf(code: string): Set<string> {
+    const all = this.allGroups();
+    const result = new Set<string>([code]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const g of all) {
+        const pc = g.pcode;
+        if (pc && result.has(pc) && g.code && !result.has(g.code)) {
+          result.add(g.code);
+          changed = true;
+        }
+      }
+    }
+    return result;
+  }
+
+  async onSubmit() {
+    this.isSubmitting.set(true);
+    await submit(this.roleForm, {
+      action: async () => {
+        const model = this.roleModel();
+        const result: Group = {
+          name: model.name,
+          description: model.description,
+          pcode: model.pcode,
+        };
+        if (!this.created()) {
+          result.id = model.id;
+          result.code = model.code;
+        }
+        this._http
+          .post<Group>(environment.secApiPath + '/groups/save', result)
+          .pipe(
+            tap(() => this._message.success(this.created() ? '角色创建成功' : '角色更新成功')),
+            delay(800),
+            takeUntilDestroyed(this._destroyRef),
+          )
+          .subscribe(() => this.closeModal());
+      },
+    });
+    this.isSubmitting.set(false);
+  }
+
+  private closeModal() {
+    const el = document.getElementById('exampleModal');
+    if (el) {
+      tabler?.Modal?.getOrCreateInstance(el)?.hide();
+    }
+  }
+}

--- a/ui/ng-plate/src/app/pages/platform/role/role.html
+++ b/ui/ng-plate/src/app/pages/platform/role/role.html
@@ -1,0 +1,251 @@
+<div class="page-header d-print-none">
+  <div class="row align-items-center">
+    <div class="col">
+      <div class="page-pretitle">系统管理</div>
+      <h2 class="page-title">角色管理</h2>
+    </div>
+    <div class="col-auto ms-auto">
+      <div class="btn-list">
+        <button class="btn btn-primary d-flex align-items-center" (click)="openRoleForm(null)">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="icon icon-tabler icon-tabler-plus me-2"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M12 5l0 14"></path>
+            <path d="M5 12l14 0"></path>
+          </svg>
+          新建角色
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="page-body">
+  <div class="row align-items-stretch g-3">
+    <!-- 左侧：角色树形结构 -->
+    <div class="col-lg-4">
+      <div class="card h-100">
+        <div class="card-header">
+          <h3 class="card-title">角色</h3>
+          <div class="card-actions">
+            <span class="badge bg-primary-lt">{{ groups().length }}</span>
+          </div>
+        </div>
+        <div class="card-body p-0 d-flex flex-column">
+          @if (isLoading()) {
+            <div class="text-center py-4">
+              <div class="spinner-border spinner-border-sm text-muted" role="status">
+                <span class="visually-hidden">加载中...</span>
+              </div>
+              <span class="ms-2 text-muted">加载中...</span>
+            </div>
+          } @else if (groups().length === 0) {
+            <div class="text-center text-muted py-5">
+              暂无角色，点击右上角「新建角色」开始创建
+            </div>
+          } @else {
+            <div class="role-tree">
+              @for (node of treeNodes(); track node.group.code) {
+                <div
+                  class="role-tree-node"
+                  [class.active]="selectedGroup()?.code === node.group.code"
+                  [style.padding-left.rem]="node.depth * 1.1 + 0.75"
+                  (click)="selectGroup(node.group)"
+                >
+                  @if (node.hasChildren) {
+                    <button
+                      type="button"
+                      class="role-tree-caret"
+                      (click)="toggleExpand(node.group.code!, $event)"
+                      [attr.aria-label]="node.expanded ? '收起' : '展开'"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="icon"
+                        [class.rotate]="!node.expanded"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        stroke-width="2"
+                        stroke="currentColor"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                        <path d="M9 6l6 6l-6 6"></path>
+                      </svg>
+                    </button>
+                  } @else {
+                    <span class="role-tree-caret-placeholder"></span>
+                  }
+                  <span class="role-tree-label">
+                    <span class="role-tree-name">{{ node.group.name }}</span>
+                    @if (node.group.description) {
+                      <span class="role-tree-desc">{{ node.group.description }}</span>
+                    }
+                  </span>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+
+    <!-- 右侧：权限 / 用户 -->
+    <div class="col-lg-8">
+      <div class="card h-100">
+        @if (!selectedGroup()) {
+          <div class="card-body d-flex align-items-center justify-content-center text-muted">
+            <div class="text-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="icon icon-lg"
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                <path
+                  d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3"
+                ></path>
+              </svg>
+              <p class="mt-3 mb-0">请从左侧选择一个角色，查看其权限与关联用户</p>
+            </div>
+          </div>
+        } @else {
+          <div class="card-header">
+            <div>
+              <h3 class="card-title mb-1">{{ selectedGroup()!.name }}</h3>
+              @if (selectedGroup()!.description) {
+                <div class="text-secondary small">{{ selectedGroup()!.description }}</div>
+              }
+            </div>
+            <div class="card-actions btn-list">
+              <button class="btn btn-outline-primary btn-sm" (click)="openRoleForm(selectedGroup())">
+                编辑
+              </button>
+              <button
+                class="btn btn-outline-danger btn-sm"
+                (click)="onDeleteGroup(selectedGroup()!)"
+              >
+                删除
+              </button>
+            </div>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <ul class="nav nav-tabs mb-3">
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  [class.active]="activeTab() === 'authority'"
+                  (click)="activeTab.set('authority')"
+                >
+                  权限 <span class="badge bg-primary-lt ms-1">{{ authorities().length }}</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  [class.active]="activeTab() === 'member'"
+                  (click)="activeTab.set('member')"
+                >
+                  用户 <span class="badge bg-primary-lt ms-1">{{ members().length }}</span>
+                </a>
+              </li>
+              <li class="nav-item ms-auto">
+                @if (activeTab() === 'authority') {
+                  <button class="btn btn-primary btn-sm" (click)="openAuthorityForm()">
+                    添加权限
+                  </button>
+                } @else {
+                  <button class="btn btn-primary btn-sm" (click)="openMemberForm()">
+                    添加用户
+                  </button>
+                }
+              </li>
+            </ul>
+
+            @if (activeTab() === 'authority') {
+              <div class="tab-pane active flex-fill">
+                @if (authorities().length === 0) {
+                  <div class="empty bg-transparent">
+                    <p class="empty-title">该角色尚未分配权限</p>
+                    <div class="empty-action">
+                      <button class="btn btn-primary" (click)="openAuthorityForm()">添加权限</button>
+                    </div>
+                  </div>
+                } @else {
+                  <div class="row g-2">
+                    @for (item of authorities(); track item.code) {
+                      <div class="col-md-6">
+                        <div class="authority-chip">
+                          <code>{{ item.authority }}</code>
+                          <button
+                            type="button"
+                            class="btn btn-ghost-danger btn-sm"
+                            (click)="onDeleteAuthority(item)"
+                            aria-label="移除权限"
+                          >
+                            ×
+                          </button>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            } @else {
+              <div class="tab-pane active flex-fill">
+                @if (members().length === 0) {
+                  <div class="empty bg-transparent">
+                    <p class="empty-title">该角色尚未关联用户</p>
+                    <div class="empty-action">
+                      <button class="btn btn-primary" (click)="openMemberForm()">添加用户</button>
+                    </div>
+                  </div>
+                } @else {
+                  <div class="list-group list-group-flush">
+                    @for (item of members(); track item.code) {
+                      <div class="list-group-item d-flex align-items-center px-0">
+                        <span class="avatar bg-primary-lt me-2">{{ (item.name || '?').slice(0, 1) }}</span>
+                        <div class="flex-fill min-w-0">
+                          <div class="fw-5 text-truncate">{{ item.name }}</div>
+                          <div class="text-secondary small text-truncate">
+                            用户编码：{{ item.userCode }}
+                          </div>
+                        </div>
+                        <button
+                          class="btn btn-outline-danger btn-sm"
+                          (click)="onDeleteMember(item)"
+                        >
+                          移除
+                        </button>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui/ng-plate/src/app/pages/platform/role/role.scss
+++ b/ui/ng-plate/src/app/pages/platform/role/role.scss
@@ -1,0 +1,104 @@
+:host {
+  display: block;
+}
+
+.role-tree {
+  overflow-y: auto;
+  max-height: calc(100vh - 220px);
+  padding: 0.5rem 0;
+}
+
+.role-tree-node {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.75rem;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.role-tree-node:hover {
+  background-color: rgba(var(--tblr-primary-rgb), 0.06);
+}
+
+.role-tree-node.active {
+  background-color: var(--tblr-primary);
+  color: #fff;
+  border-left-color: rgba(255, 255, 255, 0.65);
+}
+
+.role-tree-node.active .role-tree-desc {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.role-tree-caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  flex: none;
+}
+
+.role-tree-caret .icon {
+  transition: transform 0.15s ease;
+}
+
+.role-tree-caret .icon.rotate {
+  transform: rotate(-90deg);
+}
+
+.role-tree-caret-placeholder {
+  display: inline-block;
+  width: 1.25rem;
+  flex: none;
+}
+
+.role-tree-label {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+  min-width: 0;
+}
+
+.role-tree-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.role-tree-desc {
+  font-size: 0.75rem;
+  color: var(--tblr-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.authority-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--tblr-bg-surface-secondary, #f1f5f9);
+  border: 1px solid var(--tblr-border-color);
+  border-radius: 0.5rem;
+}
+
+.authority-chip code {
+  font-size: 0.8125rem;
+  color: var(--tblr-primary);
+  word-break: break-all;
+}

--- a/ui/ng-plate/src/app/pages/platform/role/role.ts
+++ b/ui/ng-plate/src/app/pages/platform/role/role.ts
@@ -1,0 +1,212 @@
+import { HttpClient, httpResource } from '@angular/common/http';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { delay, tap } from 'rxjs';
+import { MessageService, ModalsService } from '@app/plugins';
+import { environment } from '@envs/env';
+import { Group, GroupAuthority, GroupMember, ROOT_PCODE } from './role.types';
+import { RoleForm } from './role-form';
+import { AuthorityForm } from './authority-form';
+import { MemberForm } from './member-form';
+
+interface RoleTreeNode {
+  group: Group;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+}
+
+@Component({
+  selector: 'app-role',
+  imports: [],
+  templateUrl: './role.html',
+  styleUrl: './role.scss',
+})
+export class Role {
+  private readonly _http = inject(HttpClient);
+  private readonly _message = inject(MessageService);
+  private readonly _modal = inject(ModalsService);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  protected readonly ROOT_PCODE = ROOT_PCODE;
+
+  /** 全部角色（用于树形结构与父级选择） */
+  protected readonly groupsResource = httpResource<Group[]>(
+    () => ({
+      url: environment.secApiPath + '/groups/search',
+      params: { size: 1000 },
+    }),
+    { defaultValue: [], debugName: 'role-groups' },
+  );
+
+  /** 当前选中的角色 */
+  protected readonly selectedGroup = signal<Group | null>(null);
+  protected readonly selectedCode = computed(() => this.selectedGroup()?.code ?? null);
+
+  /** 选中角色的权限列表 */
+  protected readonly authoritiesResource = httpResource<GroupAuthority[]>(
+    () => {
+      const code = this.selectedCode();
+      if (!code) return undefined;
+      return {
+        url: environment.secApiPath + '/groups/authorities/search',
+        params: { groupCode: code, size: 1000 },
+      };
+    },
+    { defaultValue: [], debugName: 'role-authorities' },
+  );
+
+  /** 选中角色的成员列表 */
+  protected readonly membersResource = httpResource<GroupMember[]>(
+    () => {
+      const code = this.selectedCode();
+      if (!code) return undefined;
+      return {
+        url: environment.secApiPath + '/groups/members/search',
+        params: { groupCode: code, size: 1000 },
+      };
+    },
+    { defaultValue: [], debugName: 'role-members' },
+  );
+
+  protected readonly isLoading = computed(() => this.groupsResource.isLoading());
+  protected readonly groups = computed(() => this.groupsResource.value() ?? []);
+  protected readonly authorities = computed(() => this.authoritiesResource.value() ?? []);
+  protected readonly members = computed(() => this.membersResource.value() ?? []);
+
+  protected readonly activeTab = signal<'authority' | 'member'>('authority');
+
+  /** 已收起的角色编码集合（默认全部展开） */
+  private readonly collapsedCodes = signal<Set<string>>(new Set<string>());
+
+  /** 由扁平角色列表计算出的可见树节点（含缩进层级） */
+  protected readonly treeNodes = computed<RoleTreeNode[]>(() => {
+    const groups = this.groups();
+    const codeSet = new Set<string>(
+      groups.map((g) => g.code).filter((c): c is string => !!c),
+    );
+    const childrenMap = new Map<string, Group[]>();
+    for (const g of groups) {
+      const pc = g.pcode;
+      if (!pc || pc === ROOT_PCODE) continue;
+      const list = childrenMap.get(pc) ?? [];
+      list.push(g);
+      childrenMap.set(pc, list);
+    }
+    const collapsed = this.collapsedCodes();
+    const isRoot = (g: Group) => !g.pcode || g.pcode === ROOT_PCODE || !codeSet.has(g.pcode);
+    const roots = groups.filter(isRoot);
+    const result: RoleTreeNode[] = [];
+    const recurse = (list: Group[], depth: number) => {
+      for (const g of list) {
+        const children = (g.code && childrenMap.get(g.code)) || [];
+        const hasChildren = children.length > 0;
+        const expanded = g.code ? !collapsed.has(g.code) : true;
+        result.push({ group: g, depth, hasChildren, expanded });
+        if (hasChildren && expanded) recurse(children, depth + 1);
+      }
+    };
+    recurse(roots, 0);
+    return result;
+  });
+
+  protected selectGroup(group: Group): void {
+    this.selectedGroup.set(group);
+    this.activeTab.set('authority');
+  }
+
+  protected toggleExpand(code: string, event: Event): void {
+    event.stopPropagation();
+    this.collapsedCodes.update((set) => {
+      const next = new Set(set);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  }
+
+  protected openRoleForm(group: Group | null): void {
+    const ref = this._modal.create({
+      title: group ? '编辑角色' : '新建角色',
+      contentRef: RoleForm,
+      contentInputs: { inputData: group, allGroups: this.groups() },
+    });
+    outputToObservable(ref.instance.dropped)
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this.groupsResource.reload());
+  }
+
+  protected openAuthorityForm(): void {
+    const code = this.selectedCode();
+    if (!code) return;
+    const ref = this._modal.create({
+      title: '添加权限',
+      contentRef: AuthorityForm,
+      contentInputs: { groupCode: code, inputData: null },
+    });
+    outputToObservable(ref.instance.dropped)
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this.authoritiesResource.reload());
+  }
+
+  protected openMemberForm(): void {
+    const code = this.selectedCode();
+    if (!code) return;
+    const ref = this._modal.create({
+      title: '添加成员',
+      contentRef: MemberForm,
+      contentInputs: { groupCode: code },
+    });
+    outputToObservable(ref.instance.dropped)
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this.membersResource.reload());
+  }
+
+  protected onDeleteGroup(group: Group): void {
+    if (!group.code || group.id == null) return;
+    if (!confirm(`确定删除角色「${group.name ?? group.code}」吗？其下权限与成员将一并移除。`)) {
+      return;
+    }
+    this._http
+      .delete<void>(environment.secApiPath + '/groups/delete', {
+        body: { id: group.id, code: group.code },
+      })
+      .pipe(
+        tap(() => this._message.success('角色已删除')),
+        delay(800),
+        takeUntilDestroyed(this._destroyRef),
+      )
+      .subscribe(() => {
+        this.groupsResource.reload();
+        if (this.selectedCode() === group.code) this.selectedGroup.set(null);
+      });
+  }
+
+  protected onDeleteAuthority(item: GroupAuthority): void {
+    if (item.id == null) return;
+    this._http
+      .delete<void>(environment.secApiPath + '/groups/authorities/delete', {
+        body: { id: item.id, code: item.code },
+      })
+      .pipe(
+        tap(() => this._message.success('权限已移除')),
+        delay(600),
+        takeUntilDestroyed(this._destroyRef),
+      )
+      .subscribe(() => this.authoritiesResource.reload());
+  }
+
+  protected onDeleteMember(item: GroupMember): void {
+    if (item.id == null) return;
+    this._http
+      .delete<void>(environment.secApiPath + '/groups/members/delete', {
+        body: { id: item.id, code: item.code },
+      })
+      .pipe(
+        tap(() => this._message.success('成员已移除')),
+        delay(600),
+        takeUntilDestroyed(this._destroyRef),
+      )
+      .subscribe(() => this.membersResource.reload());
+  }
+}

--- a/ui/ng-plate/src/app/pages/platform/role/role.types.ts
+++ b/ui/ng-plate/src/app/pages/platform/role/role.types.ts
@@ -1,0 +1,36 @@
+import { Search, UserAuditor } from '@plate/types';
+
+/** 角色（对应后端 Group 实体，树形结构通过 pcode 关联） */
+export interface Group extends Search {
+  id?: number;
+  code?: string;
+  /** 父级角色编码，顶级角色为 ROOT_PCODE */
+  pcode?: string;
+  name?: string;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: UserAuditor;
+  updatedBy?: UserAuditor;
+  version?: number;
+}
+
+/** 角色权限（对应 GroupAuthority，authority 为权限标识字符串） */
+export interface GroupAuthority extends Search {
+  id?: number;
+  code?: string;
+  groupCode?: string;
+  authority?: string;
+}
+
+/** 角色成员（对应用户，GroupMemberRes 额外带 name） */
+export interface GroupMember extends Search {
+  id?: number;
+  code?: string;
+  groupCode?: string;
+  userCode?: string;
+  name?: string;
+}
+
+/** 顶级角色的父级编码，对应数据库 se_groups.pcode 默认值 */
+export const ROOT_PCODE = '00000000-0000-0000-0000-000000000000';


### PR DESCRIPTION
## 角色管理模块\n\n- 左侧可展开/收起的角色树，点击节点即可选中\n- 右侧 Tab 分别展示该角色的「权限」与「用户」两类数据\n- 新建 / 编辑 / 删除角色（支持树形父子层级）\n- 为角色添加或移除权限（对接 /sec/groups/authorities）\n- 为角色添加或移除用户成员（对接 /sec/groups/members）\n- 已接入系统管理路由与左侧导航\n\n后端接口：/sec/groups、/sec/groups/authorities、/sec/groups/members。
