### PR TITLE
fix: remove hardcoded captcha bypass, enable CaptchaFilter, fix NPE and routing bugs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,72 @@
+# =============================================================================
+# .gitattributes — cross-platform line-ending and file-type normalization
+# Goal: every developer gets the same checkout regardless of OS (Windows/macOS/Linux)
+#       and the Gradle wrapper stays executable and LF-only.
+# =============================================================================
+
+# Default: auto-detect text vs binary, and normalize line endings to LF on commit.
+# On checkout, text files become LF on macOS/Linux and CRLF on Windows (Git's default
+# for `text=auto`). If you want strictly LF everywhere, switch to `* text=auto eol=lf`.
+* text=auto
+
+# -----------------------------------------------------------------------------
+# Gradle wrapper — MUST remain executable and LF-only, or `./gradlew` breaks on clone
+# -----------------------------------------------------------------------------
+boot/gradlew    text eol=lf
+boot/gradlew.bat text eol=crlf
+gradlew         text eol=lf
+gradlew.bat     text eol=crlf
+
+# -----------------------------------------------------------------------------
+# Shell scripts (force LF so they don't get CRLF'd and break under bash)
+# -----------------------------------------------------------------------------
+*.sh            text eol=lf
+
+# Windows batch / cmd files (CRLF is expected on Windows)
+*.bat           text eol=crlf
+*.cmd           text eol=crlf
+
+# -----------------------------------------------------------------------------
+# Backend: Java / Gradle / Kotlin
+# -----------------------------------------------------------------------------
+*.java          text
+*.gradle        text
+*.gradle.kts    text
+gradle.properties text
+*.kt            text
+*.kts           text
+
+# -----------------------------------------------------------------------------
+# Frontend: Angular / TypeScript / pnpm
+# -----------------------------------------------------------------------------
+*.ts            text
+*.tsx           text
+*.js            text
+*.mjs           text
+*.json          text
+*.html          text
+*.css           text
+*.scss          text
+*.md            text
+
+# Lockfiles must stay LF and must never be merged as "binary"
+pnpm-lock.yaml  text eol=lf
+package-lock.json text eol=lf
+yarn.lock       text eol=lf
+
+# -----------------------------------------------------------------------------
+# Binary assets — do not diff or normalize (keep stored bytes intact)
+# -----------------------------------------------------------------------------
+*.jar           binary
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.webp          binary
+*.woff          binary
+*.woff2         binary
+*.ttf           binary
+*.eot           binary
+*.pdf           binary
+*.zip           binary

--- a/boot/platform/src/main/java/com/plate/boot/relational/dictionaries/DictionariesController.java
+++ b/boot/platform/src/main/java/com/plate/boot/relational/dictionaries/DictionariesController.java
@@ -38,7 +38,7 @@ import java.util.UUID;
  */
 @Log4j2
 @RestController
-@RequestMapping("/rel/dictionaries")
+@RequestMapping("/dictionaries")
 @RequiredArgsConstructor
 @Tag(name = "Dictionaries", description = "Dictionary management APIs for managing system data dictionaries and configurations")
 public class DictionariesController {

--- a/boot/platform/src/main/java/com/plate/boot/security/AuthenticationToken.java
+++ b/boot/platform/src/main/java/com/plate/boot/security/AuthenticationToken.java
@@ -4,6 +4,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.server.WebSession;
 
 import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Represents an immutable data structure for holding authentication token details, including the token string, expiration timestamp,
@@ -42,7 +44,10 @@ public record AuthenticationToken(String token, Long expires, Long lastAccessTim
      * @return A newly built {@link AuthenticationToken} representing the authenticated user's session with relevant metadata.
      */
     public static AuthenticationToken build(WebSession session, Object principal) {
-        return of(session.getId(), session.getMaxIdleTime().getSeconds(),
-                session.getLastAccessTime().getEpochSecond(), principal);
+        Instant lastAccessTime = session.getLastAccessTime();
+        long lastAccessSeconds = (lastAccessTime != null ? lastAccessTime : Instant.now()).getEpochSecond();
+        Duration maxIdleTime = session.getMaxIdleTime();
+        long maxIdleSeconds = (maxIdleTime != null ? maxIdleTime : Duration.ofSeconds(1800)).getSeconds();
+        return of(session.getId(), maxIdleSeconds, lastAccessSeconds, principal);
     }
 }

--- a/boot/platform/src/main/java/com/plate/boot/security/captcha/CaptchaFilter.java
+++ b/boot/platform/src/main/java/com/plate/boot/security/captcha/CaptchaFilter.java
@@ -3,6 +3,7 @@ package com.plate.boot.security.captcha;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -27,7 +28,7 @@ import static com.plate.boot.security.captcha.CaptchaRepository.DEFAULT_CAPTCHA_
  * It integrates with session management and captcha token validation to prevent unauthorized access.
  */
 @Log4j2
-//@Component
+@Component
 @RequiredArgsConstructor
 public class CaptchaFilter implements WebFilter, Ordered {
 

--- a/boot/platform/src/main/java/com/plate/boot/security/captcha/CaptchaRepository.java
+++ b/boot/platform/src/main/java/com/plate/boot/security/captcha/CaptchaRepository.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Captcha Repository service class, used to generate, save, load and clear captcha tokens
@@ -30,6 +31,11 @@ public class CaptchaRepository {
      * Default captcha header name
      */
     static final String DEFAULT_CAPTCHA_HEADER_NAME = "X-CAPTCHA-TOKEN";
+
+    /**
+     * Number of digits contained in a generated captcha code.
+     */
+    private static final int CAPTCHA_CODE_LENGTH = 5;
 
     protected String parameterName = DEFAULT_CAPTCHA_PARAMETER_NAME;
     protected String headerName = DEFAULT_CAPTCHA_HEADER_NAME;
@@ -101,7 +107,11 @@ public class CaptchaRepository {
      * @return Newly created captcha token
      */
     protected CaptchaToken createCaptchaToken() {
-        return CaptchaToken.of(this.headerName, this.parameterName, "54321");
+        StringBuilder captchaCode = new StringBuilder(CAPTCHA_CODE_LENGTH);
+        for (int i = 0; i < CAPTCHA_CODE_LENGTH; i++) {
+            captchaCode.append(ThreadLocalRandom.current().nextInt(10));
+        }
+        return CaptchaToken.of(this.headerName, this.parameterName, captchaCode.toString());
     }
 
 }

--- a/boot/platform/src/main/java/com/plate/boot/security/core/user/authority/UserAuthoritiesService.java
+++ b/boot/platform/src/main/java/com/plate/boot/security/core/user/authority/UserAuthoritiesService.java
@@ -70,7 +70,7 @@ public class UserAuthoritiesService {
      */
     @CacheEvict(cacheNames = "user-authorities", allEntries = true)
     public Mono<Void> delete(UserAuthorityReq request) {
-        return this.authoritiesRepository.findByCode(request.getCode())
+        return this.authoritiesRepository.findById(request.getId())
                 .flatMap(this.authoritiesRepository::delete);
     }
 

--- a/boot/platform/src/test/java/com/plate/boot/ApplicationContextTests.java
+++ b/boot/platform/src/test/java/com/plate/boot/ApplicationContextTests.java
@@ -52,6 +52,12 @@ class ApplicationContextTests extends AbstractIntegrationTests {
             assertThat(applicationContext.containsBean("passwordEncoder")).isTrue();
             assertThat(applicationContext.containsBean("securityManager")).isTrue();
         }
+
+        @Test
+        @DisplayName("should register the captcha filter as a Spring bean")
+        void shouldRegisterCaptchaFilter() {
+            assertThat(applicationContext.containsBean("captchaFilter")).isTrue();
+        }
     }
 
     @Nested

--- a/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractCacheTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractCacheTest.java
@@ -1,0 +1,56 @@
+package com.plate.boot.commons.base;
+
+import com.plate.boot.commons.utils.ContextUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pure cache-initialisation logic in {@link AbstractCache}
+ * (no Spring / R2DBC connection required).
+ * <p>
+ * When {@link ContextUtils#CACHE_MANAGER} is {@code null}, {@code initializingCache} falls back to a
+ * local {@link ConcurrentMapCache}. The SQL-bound {@code queryWithCache}/{@code countWithCache}
+ * helpers depend on the static {@code DatabaseUtils} template/client, which are only populated by
+ * Spring, so they are intentionally NOT tested here (see report).
+ */
+class AbstractCacheTest {
+
+    private static org.springframework.cache.CacheManager savedManager;
+
+    @BeforeAll
+    static void setUp() {
+        savedManager = ContextUtils.CACHE_MANAGER;
+        ContextUtils.CACHE_MANAGER = null;
+    }
+
+    @AfterAll
+    static void tearDown() {
+        ContextUtils.CACHE_MANAGER = savedManager;
+    }
+
+    static class TestCache extends AbstractCache {
+    }
+
+    @Test
+    void afterPropertiesSetInitialisesLocalCache() {
+        TestCache cache = new TestCache();
+        cache.afterPropertiesSet();
+
+        assertThat(cache.cache).isNotNull();
+        assertThat(cache.cache).isInstanceOf(ConcurrentMapCache.class);
+        assertThat(cache.cache.getName()).endsWith(".cache");
+    }
+
+    @Test
+    void initializingCacheFallsBackToConcurrentMapCache() {
+        Cache cache = new TestCache().initializingCache("custom.cache");
+
+        assertThat(cache).isInstanceOf(ConcurrentMapCache.class);
+        assertThat(cache.getName()).isEqualTo("custom.cache");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractEntityTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractEntityTest.java
@@ -1,0 +1,70 @@
+package com.plate.boot.commons.base;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pure logic in {@link AbstractEntity} (no Spring / container required).
+ * {@code isNew()} assigns a UUIDv7 code when absent; identity is based on the {@code id} field.
+ */
+class AbstractEntityTest {
+
+    @Table("test_entity")
+    static class TestEntity extends AbstractEntity<UUID> {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void isNewAssignsUuidV7WhenCodeAbsent() {
+        TestEntity entity = new TestEntity();
+
+        boolean isNew = entity.isNew();
+
+        assertThat(isNew).isTrue();
+        assertThat(entity.getCode()).isNotNull();
+        assertThat(entity.getCode().version()).isEqualTo(7);
+    }
+
+    @Test
+    void isNewReturnsFalseWhenIdPresent() {
+        TestEntity entity = new TestEntity();
+        entity.setId(UUID.randomUUID());
+
+        assertThat(entity.isNew()).isFalse();
+    }
+
+    @Test
+    void equalsAndHashCodeBasedOnId() {
+        TestEntity a = new TestEntity();
+        a.setId(UUID.randomUUID());
+        TestEntity b = new TestEntity();
+        b.setId(a.getId());
+        TestEntity c = new TestEntity();
+        c.setId(UUID.randomUUID());
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(c);
+    }
+
+    @Test
+    void versionDefaultsToNull() {
+        assertThat(new TestEntity().getVersion()).isNull();
+    }
+
+    @Test
+    void queryDefaultsToNull() {
+        assertThat(new TestEntity().getQuery()).isNull();
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractEventTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/base/AbstractEventTest.java
@@ -1,0 +1,41 @@
+package com.plate.boot.commons.base;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AbstractEvent} (no Spring / container required).
+ * The event captures its entity, kind, and resolvable type; equality honours those.
+ */
+class AbstractEventTest {
+
+    static class StringEvent extends AbstractEvent<String> {
+        StringEvent(String entity, Kind kind) {
+            super(entity, kind);
+        }
+    }
+
+    @Test
+    void exposesEntityKindAndType() {
+        StringEvent event = new StringEvent("hello", AbstractEvent.Kind.INSERT);
+
+        assertThat(event.getEntity()).isEqualTo("hello");
+        assertThat(event.getKind()).isEqualTo(AbstractEvent.Kind.INSERT);
+        assertThat(event.getType()).isEqualTo(StringEvent.class);
+        assertThat(event.getResolvableType().getType()).isEqualTo(StringEvent.class);
+    }
+
+    @Test
+    void equalsBasedOnEntityAndKind() {
+        StringEvent a = new StringEvent("x", AbstractEvent.Kind.UPDATE);
+        StringEvent c = new StringEvent("x", AbstractEvent.Kind.DELETE);
+
+        // AbstractEvent uses @EqualsAndHashCode(callSuper = true); its superclass
+        // (AbstractRelationalEvent) is identity-based, so two distinct event instances
+        // are never equal — equality is reference equality.
+        assertThat(a).isEqualTo(a);
+        assertThat(a).isNotEqualTo(c);
+        assertThat(a).isNotEqualTo("not an event");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/base/BaseEntityTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/base/BaseEntityTest.java
@@ -1,0 +1,47 @@
+package com.plate.boot.commons.base;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the default methods declared on {@link BaseEntity} (no Spring / container required).
+ * {@code criteria(...)} and {@code query(...)} build Spring {@code Criteria}/{@code QueryFragment}
+ * purely from the entity's bean properties and its {@code @Table} name.
+ */
+class BaseEntityTest {
+
+    @Table("test_entity")
+    static class TestEntity extends AbstractEntity<UUID> {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void criteriaReturnsNonNullCriteria() {
+        TestEntity entity = new TestEntity();
+
+        assertThat(entity.criteria(List.of())).isNotNull();
+    }
+
+    @Test
+    void queryBuildsSqlFromTableName() {
+        TestEntity entity = new TestEntity();
+
+        String sql = entity.query(List.of()).querySql();
+
+        assertThat(sql).contains("FROM test_entity");
+        assertThat(sql).contains("LIMIT 25 OFFSET 0");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/base/BaseViewTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/base/BaseViewTest.java
@@ -1,0 +1,24 @@
+package com.plate.boot.commons.base;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Trivial structural test for the {@link BaseView} marker interfaces (no behaviour to exercise).
+ */
+class BaseViewTest {
+
+    @Test
+    void nestedViewInterfacesAreInterfacesWithExpectedHierarchy() {
+        assertThat(BaseView.Public.class).isInterface();
+        assertThat(BaseView.Hidden.class).isInterface();
+        assertThat(BaseView.Detail.class).isInterface();
+        assertThat(BaseView.Admin.class).isInterface();
+
+        // Admin -> Detail -> Public
+        assertThat(BaseView.Public.class.isAssignableFrom(BaseView.Detail.class)).isTrue();
+        assertThat(BaseView.Public.class.isAssignableFrom(BaseView.Admin.class)).isTrue();
+        assertThat(BaseView.Detail.class.isAssignableFrom(BaseView.Admin.class)).isTrue();
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/converters/CustomTypesConvertersTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/converters/CustomTypesConvertersTest.java
@@ -1,0 +1,40 @@
+package com.plate.boot.commons.converters;
+
+import com.plate.boot.relational.MethodType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the pure converter logic in {@link CustomTypesConverters}.
+ * {@code MethodTypeReadConverter} uses {@link MethodType#valueOf(String)} (throwing
+ * {@link IllegalArgumentException} on unknown values); {@code MethodTypeWriteConverter}
+ * uses {@link MethodType#name()}.
+ */
+class CustomTypesConvertersTest {
+
+    @Test
+    void methodTypeReadConverterResolvesKnownMethod() {
+        var converter = new CustomTypesConverters.MethodTypeReadConverter();
+
+        assertThat(converter.convert("POST")).isEqualTo(MethodType.POST);
+        assertThat(converter.convert("PUT")).isEqualTo(MethodType.PUT);
+    }
+
+    @Test
+    void methodTypeReadConverterThrowsForUnknownMethod() {
+        var converter = new CustomTypesConverters.MethodTypeReadConverter();
+
+        assertThatThrownBy(() -> converter.convert("NOPE"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void methodTypeWriteConverterReturnsName() {
+        var converter = new CustomTypesConverters.MethodTypeWriteConverter();
+
+        assertThat(converter.convert(MethodType.DELETE)).isEqualTo("DELETE");
+        assertThat(converter.convert(MethodType.UNKNOWN)).isEqualTo("UNKNOWN");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/converters/JsonNodeConvertersTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/converters/JsonNodeConvertersTest.java
@@ -1,0 +1,101 @@
+package com.plate.boot.commons.converters;
+
+import com.plate.boot.commons.exception.JsonException;
+import com.plate.boot.commons.exception.RestServerException;
+import com.plate.boot.commons.utils.ContextUtils;
+import io.r2dbc.postgresql.codec.Json;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the pure converter logic in {@link JsonNodeConverters}.
+ * No Spring / R2DBC connection is required: only the nested {@code Converter}
+ * implementations and the static {@link ContextUtils#OBJECT_MAPPER} are exercised.
+ */
+class JsonNodeConvertersTest {
+
+    private static JsonMapper savedMapper;
+
+    @BeforeAll
+    static void setUp() {
+        savedMapper = ContextUtils.OBJECT_MAPPER;
+        ContextUtils.OBJECT_MAPPER = JsonMapper.builder().build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        ContextUtils.OBJECT_MAPPER = savedMapper;
+    }
+
+    @Test
+    void methodTypeReadConverterResolvesKnownMethod() {
+        var converter = new JsonNodeConverters.MethodTypeReadConverter();
+
+        assertThat(converter.convert("POST")).isEqualTo(com.plate.boot.relational.MethodType.POST);
+        assertThat(converter.convert("DELETE")).isEqualTo(com.plate.boot.relational.MethodType.DELETE);
+    }
+
+    @Test
+    void methodTypeReadConverterThrowsForUnknownMethod() {
+        var converter = new JsonNodeConverters.MethodTypeReadConverter();
+
+        assertThatThrownBy(() -> converter.convert("NOT_A_METHOD"))
+                .isInstanceOf(RestServerException.class);
+    }
+
+    @Test
+    void methodTypeWriteConverterReturnsName() {
+        var converter = new JsonNodeConverters.MethodTypeWriteConverter();
+
+        assertThat(converter.convert(com.plate.boot.relational.MethodType.PUT)).isEqualTo("PUT");
+    }
+
+    @Test
+    void jsonWriteConverterWrapsNodeAsJson() {
+        var converter = new JsonNodeConverters.JsonToNodeWriteConverter();
+        JsonNode node = ContextUtils.OBJECT_MAPPER.createObjectNode().put("name", "John").put("age", 30);
+
+        Json json = converter.convert(node);
+
+        assertThat(json).isNotNull();
+    }
+
+    @Test
+    void jsonReadConverterParsesJsonBackToNode() {
+        var read = new JsonNodeConverters.JsonToNodeReadConverter();
+        Json json = Json.of("{\"name\":\"John\",\"age\":30}");
+
+        JsonNode node = read.convert(json);
+
+        assertThat(node).isNotNull();
+        assertThat(node.get("name").asText()).isEqualTo("John");
+        assertThat(node.get("age").asInt()).isEqualTo(30);
+    }
+
+    @Test
+    void jsonWriteThenReadConverterRoundTrips() {
+        var write = new JsonNodeConverters.JsonToNodeWriteConverter();
+        var read = new JsonNodeConverters.JsonToNodeReadConverter();
+        JsonNode original = ContextUtils.OBJECT_MAPPER.createObjectNode().put("active", true);
+
+        Json json = write.convert(original);
+        JsonNode restored = read.convert(json);
+
+        assertThat(restored).isEqualTo(original);
+    }
+
+    @Test
+    void jsonReadConverterThrowsJsonExceptionOnInvalidJson() {
+        var read = new JsonNodeConverters.JsonToNodeReadConverter();
+        Json json = Json.of("this is not valid json");
+
+        assertThatThrownBy(() -> read.convert(json))
+                .isInstanceOf(JsonException.class);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/converters/UserAuditorConvertersTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/converters/UserAuditorConvertersTest.java
@@ -1,0 +1,36 @@
+package com.plate.boot.commons.converters;
+
+import com.plate.boot.security.core.UserAuditor;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pure converter logic in {@link UserAuditorConverters}.
+ * No Spring / R2DBC connection is required.
+ */
+class UserAuditorConvertersTest {
+
+    @Test
+    void writeConverterReturnsCode() {
+        UUID code = UUID.randomUUID();
+        UserAuditor auditor = UserAuditor.of(code, "Alice");
+
+        UUID result = new UserAuditorConverters.UserAuditorWriteConverter().convert(auditor);
+
+        assertThat(result).isEqualTo(code);
+    }
+
+    @Test
+    void readConverterBuildsUserAuditorWithCode() {
+        UUID code = UUID.randomUUID();
+
+        UserAuditor result = new UserAuditorConverters.UserAuditorReadConverter().convert(code);
+
+        assertThat(result).isEqualTo(UserAuditor.withCode(code));
+        assertThat(result.code()).isEqualTo(code);
+        assertThat(result.name()).isNull();
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/exception/JsonExceptionTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/exception/JsonExceptionTest.java
@@ -1,0 +1,54 @@
+package com.plate.boot.commons.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link JsonException} (no Spring / container required).
+ */
+class JsonExceptionTest {
+
+    private final Throwable cause = new RuntimeException("parse failure");
+
+    @Test
+    void constructorWithThrowableUsesDefaultMessage() {
+        JsonException ex = new JsonException(cause);
+
+        assertThat(ex.getReason()).isEqualTo("Json processing exception");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void constructorWithMessageAndThrowableStoresBoth() {
+        JsonException ex = new JsonException("custom json error", cause);
+
+        assertThat(ex.getReason()).isEqualTo("custom json error");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void withErrorThrowableReturnsJsonException() {
+        JsonException ex = JsonException.withError(cause);
+
+        assertThat(ex).isInstanceOf(JsonException.class);
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void withErrorMessageAndThrowableReturnsJsonPointerException() {
+        JsonPointerException ex = JsonException.withError("pointer error", cause);
+
+        assertThat(ex).isInstanceOf(JsonPointerException.class);
+        assertThat(ex.getReason()).isEqualTo("pointer error");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void isThrowAsRuntimeException() {
+        assertThatThrownBy(() -> {
+            throw new JsonException(cause);
+        }).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/exception/JsonPointerExceptionTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/exception/JsonPointerExceptionTest.java
@@ -1,0 +1,40 @@
+package com.plate.boot.commons.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link JsonPointerException} (no Spring / container required).
+ */
+class JsonPointerExceptionTest {
+
+    private final Throwable cause = new RuntimeException("missing path");
+
+    @Test
+    void constructorStoresMessageAndCause() {
+        JsonPointerException ex = new JsonPointerException("pointer failure", cause);
+
+        assertThat(ex.getReason()).isEqualTo("pointer failure");
+        assertThat(ex.getCause()).isSameAs(cause);
+        assertThat(ex).isInstanceOf(JsonException.class);
+    }
+
+    @Test
+    void withErrorFactoryReturnsInstance() {
+        JsonPointerException ex = JsonPointerException.withError("pointer failure", cause);
+
+        assertThat(ex.getReason()).isEqualTo("pointer failure");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void equalsBasedOnMessageAndCause() {
+        JsonPointerException a = new JsonPointerException("m", cause);
+        JsonPointerException c = new JsonPointerException("other", cause);
+
+        assertThat(a).isEqualTo(a);
+        assertThat(a).isNotEqualTo(c);
+        assertThat(a).isNotEqualTo("not an exception");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/exception/QueryExceptionTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/exception/QueryExceptionTest.java
@@ -1,0 +1,40 @@
+package com.plate.boot.commons.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link QueryException} (no Spring / container required).
+ */
+class QueryExceptionTest {
+
+    private final Throwable cause = new RuntimeException("db failure");
+
+    @Test
+    void constructorStoresMessageAndCause() {
+        QueryException ex = new QueryException("bad query", cause);
+
+        assertThat(ex.getReason()).isEqualTo("bad query");
+        assertThat(ex.getCause()).isSameAs(cause);
+        assertThat(ex).isInstanceOf(RestServerException.class);
+    }
+
+    @Test
+    void withErrorFactoryReturnsEquivalentInstance() {
+        QueryException ex = QueryException.withError("bad query", cause);
+
+        assertThat(ex.getReason()).isEqualTo("bad query");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void equalsBasedOnMessageAndCause() {
+        QueryException a = new QueryException("m", cause);
+        QueryException c = new QueryException("other", cause);
+
+        assertThat(a).isEqualTo(a);
+        assertThat(a).isNotEqualTo(c);
+        assertThat(a).isNotEqualTo("not an exception");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/exception/RestServerExceptionTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/exception/RestServerExceptionTest.java
@@ -1,0 +1,102 @@
+package com.plate.boot.commons.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link RestServerException} (no Spring / container required).
+ */
+class RestServerExceptionTest {
+
+    private final Throwable cause = new IllegalStateException("root cause");
+
+    /**
+     * A non-null {@link MethodParameter} so the Spring {@code ServerErrorException} base
+     * constructor does not NPE (it dereferences the parameter internally).
+     */
+    private static final MethodParameter SAMPLE_PARAMETER;
+
+    static {
+        try {
+            SAMPLE_PARAMETER = new MethodParameter(
+                    RestServerExceptionTest.class.getDeclaredMethod("sample", String.class), 0);
+        } catch (NoSuchMethodException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    void sample(String param) {
+    }
+
+    @Test
+    void constructorWithReasonAndCauseStoresMessageAndCause() {
+        RestServerException ex = new RestServerException("boom", cause);
+
+        assertThat(ex.getReason()).isEqualTo("boom");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void constructorWithHandlerMethodAndCauseDoesNotThrow() {
+        Method method = RestServerExceptionTest.class.getDeclaredMethods()[0];
+        RestServerException ex = new RestServerException("handler boom", method, cause);
+
+        assertThat(ex.getReason()).isEqualTo("handler boom");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void constructorWithMethodParameterAndCauseDoesNotThrow() {
+        RestServerException ex = new RestServerException("param boom", SAMPLE_PARAMETER, cause);
+
+        assertThat(ex.getReason()).isEqualTo("param boom");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void withMsgStoresReasonAndIsARestServerException() {
+        RestServerException ex = RestServerException.withMsg("with-msg", cause);
+
+        assertThat(ex).isInstanceOf(RestServerException.class);
+        assertThat(ex.getReason()).isEqualTo("with-msg");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void withMsgWithHandlerMethodReturnsInstance() {
+        Method method = RestServerExceptionTest.class.getDeclaredMethods()[0];
+        RestServerException ex = RestServerException.withMsg("m", method, cause);
+
+        assertThat(ex.getReason()).isEqualTo("m");
+    }
+
+    @Test
+    void withMsgWithMethodParameterReturnsInstance() {
+        RestServerException ex = RestServerException.withMsg("p", SAMPLE_PARAMETER, cause);
+
+        assertThat(ex.getReason()).isEqualTo("p");
+    }
+
+    @Test
+    void equalsAndHashCodeHonourReasonAndCause() {
+        RestServerException a = new RestServerException("same", cause);
+        RestServerException c = new RestServerException("different", cause);
+
+        assertThat(a).isEqualTo(a);
+        assertThat(a).isNotEqualTo(c);
+        assertThat(a).isNotEqualTo("not an exception");
+    }
+
+    @Test
+    void isARuntimeExceptionSoCanBeThrownAnywhere() {
+        assertThatThrownBy(() -> {
+            throw new RestServerException("x", cause);
+        }).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/query/QueryFragmentTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/query/QueryFragmentTest.java
@@ -1,0 +1,222 @@
+package com.plate.boot.commons.query;
+
+import com.plate.boot.commons.exception.QueryException;
+import com.plate.boot.commons.utils.DatabaseUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.r2dbc.convert.R2dbcConverter;
+import org.springframework.data.relational.core.query.Criteria;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link QueryFragment} (no Spring / container required).
+ * Focus: SQL fragment assembly, pagination, and parameterised conditions
+ * (user values must be bound, never concatenated).
+ */
+class QueryFragmentTest {
+
+    private static R2dbcConverter savedConverter;
+
+    @BeforeEach
+    void setUpConverter() {
+        savedConverter = DatabaseUtils.R2DBC_CONVERTER;
+        R2dbcConverter stub = mock(R2dbcConverter.class);
+        when(stub.writeValue(any(), any(org.springframework.data.core.TypeInformation.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        DatabaseUtils.R2DBC_CONVERTER = stub;
+    }
+
+    @AfterEach
+    void tearDownConverter() {
+        DatabaseUtils.R2DBC_CONVERTER = savedConverter;
+    }
+
+
+    @Test
+    void buildsBasicSelectSql() {
+        String sql = QueryFragment.from("users")
+                .column("id", "name")
+                .where("active = :active")
+                .orderBy("name ASC")
+                .groupBy("tenant")
+                .querySql();
+
+        assertThat(sql).contains("SELECT id,name")
+                .contains("FROM users")
+                .contains("WHERE active = :active")
+                .contains("GROUP BY tenant")
+                .contains("ORDER BY name ASC")
+                .contains("LIMIT 25 OFFSET 0");
+    }
+
+    @Test
+    void querySqlWithoutFromThrows() {
+        assertThatThrownBy(() -> QueryFragment.from().querySql())
+                .isInstanceOf(QueryException.class);
+    }
+
+    @Test
+    void countSqlWrapsSubQuery() {
+        String sql = QueryFragment.from("users").where("active = :active").countSql();
+
+        assertThat(sql).contains("SELECT COUNT(*) FROM (SELECT 1 FROM users WHERE active = :active) t");
+    }
+
+    @Test
+    void countSqlWithoutFromThrows() {
+        assertThatThrownBy(() -> QueryFragment.from().countSql())
+                .isInstanceOf(QueryException.class);
+    }
+
+    @Test
+    void emptyClausesRenderToDefaults() {
+        QueryFragment f = QueryFragment.from("users");
+
+        assertThat(f.columnSql()).isEqualTo("*");
+        assertThat(f.whereSql()).isEmpty();
+        assertThat(f.orderSql()).isEmpty();
+        assertThat(f.groupSql()).isEmpty();
+    }
+
+    @Test
+    void inBindsValuesAsParameters() {
+        QueryFragment f = QueryFragment.from("users").in("status", List.of("active", "pending"));
+        String where = f.whereSql();
+
+        assertThat(where).contains("status IN (:").doesNotContain("active").doesNotContain("pending");
+        assertThat(f.get("status0")).isEqualTo("active");
+        assertThat(f.get("status1")).isEqualTo("pending");
+    }
+
+    @Test
+    void inDoesNotConcatenateMaliciousValues() {
+        String malicious = "x'); DROP TABLE t; --";
+        QueryFragment f = QueryFragment.from("users").in("status", List.of(malicious));
+
+        assertThat(f.whereSql()).doesNotContain(malicious);
+        assertThat(f.get("status0")).isEqualTo(malicious);
+    }
+
+    @Test
+    void notInBindsValuesAsParameters() {
+        QueryFragment f = QueryFragment.from("users").notIn("status", List.of("banned"));
+        String where = f.whereSql();
+
+        assertThat(where).contains("status NOT IN (:").doesNotContain("banned");
+        assertThat(f.get("status0")).isEqualTo("banned");
+    }
+
+    @Test
+    void likeConditionsBindValue() {
+        QueryFragment f = QueryFragment.from("users")
+                .like("name", "John")
+                .startingWith("code", "A")
+                .endingWith("email", "com")
+                .notLike("note", "spam");
+
+        String where = f.whereSql();
+        assertThat(where).contains("name LIKE :").contains("code LIKE :").contains("email LIKE :").contains("note NOT LIKE :");
+        assertThat(where).doesNotContain("John").doesNotContain("spam");
+    }
+
+    @Test
+    void betweenBindsBothBounds() {
+        QueryFragment f = QueryFragment.from("users").between("age", 18, 65);
+
+        assertThat(f.whereSql()).contains("age BETWEEN :age1 AND :age2");
+        assertThat(f.get("age1")).isEqualTo(18);
+        assertThat(f.get("age2")).isEqualTo(65);
+    }
+
+    @Test
+    void nullComparisonsNeedNoBoundValue() {
+        QueryFragment f = QueryFragment.from("users")
+                .isNull("deleted_at")
+                .isNotNull("verified_at")
+                .isTrue("enabled")
+                .isFalse("locked");
+
+        String where = f.whereSql();
+        assertThat(where).contains("deleted_at IS NULL")
+                .contains("verified_at IS NOT NULL")
+                .contains("enabled IS TRUE")
+                .contains("locked IS FALSE");
+        assertThat(f).doesNotContainKey("deleted_at");
+    }
+
+    @Test
+    void comparisonOperatorsBindValue() {
+        QueryFragment f = QueryFragment.from("users")
+                .after("created_at", 100)
+                .before("expires_at", 200)
+                .greaterThanOrEqual("score", 1)
+                .lessThanOrEqual("score", 9)
+                .isEq("tenant", 42)
+                .not("legacy", 0);
+
+        String where = f.whereSql();
+        assertThat(where).contains("created_at > :").contains("expires_at < :")
+                .contains("score >= :").contains("score <= :")
+                .contains("tenant = :").contains("legacy != :");
+        assertThat(f.get("tenant")).isEqualTo(42);
+    }
+
+    @Test
+    void tsBuildsFullTextSearchWithBoundParameter() {
+        String malicious = "'; DROP TABLE t; --";
+        QueryFragment f = QueryFragment.from("docs").ts("text_search", malicious);
+
+        String sql = f.querySql();
+        assertThat(sql).contains("TO_TSQUERY('chinese',:text_search)")
+                .contains("text_search @@ text_search")
+                .contains(":text_search");
+        assertThat(sql).doesNotContain(malicious);
+        assertThat(f.get("text_search")).isEqualTo(malicious);
+    }
+
+    @Test
+    void pageableAppliesLimitOffsetAndSort() {
+        QueryFragment f = QueryFragment.from("users")
+                .pageable(PageRequest.of(2, 15, Sort.by(Sort.Order.desc("created_at"))));
+
+        assertThat(f.getSize()).isEqualTo(15);
+        assertThat(f.getOffset()).isEqualTo(30);
+        assertThat(f.orderSql()).contains("created_at DESC");
+    }
+
+    @Test
+    void conditionAddsSqlAndParametersFromCriteria() {
+        Criteria criteria = Criteria.where("name").like("Bob").ignoreCase(true);
+        QueryFragment f = QueryFragment.from("users").condition(QueryFragment.Condition.of(criteria));
+
+        assertThat(f.whereSql()).contains("name LIKE :");
+        assertThat(f.whereSql()).doesNotContain("Bob");
+    }
+
+    @Test
+    void conditionWithPrefixQualifiesColumn() {
+        Criteria criteria = Criteria.where("id").is(1);
+        QueryFragment.Condition condition = QueryFragment.Condition.of(criteria, "u");
+        String sql = condition.toSql();
+
+        assertThat(sql).contains("u.id = :");
+    }
+
+    @Test
+    void conditionalFactoryBuildsFromConditions() {
+        Criteria criteria = Criteria.where("active").is(true);
+        QueryFragment f = QueryFragment.conditional(QueryFragment.Condition.of(criteria));
+
+        assertThat(f.whereSql()).contains("active = :");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/query/QueryHelperTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/query/QueryHelperTest.java
@@ -1,0 +1,165 @@
+package com.plate.boot.commons.query;
+
+import com.plate.boot.commons.exception.QueryException;
+import com.plate.boot.commons.exception.RestServerException;
+import com.plate.boot.commons.utils.DatabaseUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.r2dbc.convert.R2dbcConverter;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.core.query.Criteria;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link QueryHelper} (no Spring / container required).
+ * Focus: table-name resolution, criteria construction, and verifying that user
+ * values are bound as parameters rather than concatenated into raw SQL.
+ */
+class QueryHelperTest {
+
+    @Table("my_table")
+    static class AnnotatedTable {
+    }
+
+    @Table("")
+    static class EmptyTable {
+    }
+
+    static class NoTable {
+    }
+
+    private static R2dbcConverter savedConverter;
+
+    @BeforeEach
+    void setUpConverter() {
+        savedConverter = DatabaseUtils.R2DBC_CONVERTER;
+        R2dbcConverter stub = mock(R2dbcConverter.class);
+        when(stub.writeValue(any(), any(org.springframework.data.core.TypeInformation.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        DatabaseUtils.R2DBC_CONVERTER = stub;
+    }
+
+    @AfterEach
+    void tearDownConverter() {
+        DatabaseUtils.R2DBC_CONVERTER = savedConverter;
+    }
+
+    @Test
+    void annotationTableNameUsesTableValue() {
+        assertThat(QueryHelper.annotationTableName(new AnnotatedTable())).isEqualTo("my_table");
+    }
+
+    @Test
+    void annotationTableNameFallsBackToSnakeCaseWhenValueEmpty() {
+        assertThat(QueryHelper.annotationTableName(new EmptyTable())).isEqualTo("empty_table");
+    }
+
+    @Test
+    void annotationTableNameThrowsForNull() {
+        assertThatThrownBy(() -> QueryHelper.annotationTableName(null))
+                .isInstanceOf(RestServerException.class);
+    }
+
+    @Test
+    void annotationTableNameThrowsWhenNoAnnotation() {
+        assertThatThrownBy(() -> QueryHelper.annotationTableName(new java.util.HashMap<>()))
+                .isInstanceOf(RestServerException.class);
+    }
+
+    @Test
+    void criteriaFromEmptyMapIsEmpty() {
+        Criteria criteria = QueryHelper.criteria(Map.of());
+
+        assertThat(criteria).isEqualTo(Criteria.empty());
+        assertThat(QueryFragment.Condition.of(criteria).toSql()).isEmpty();
+    }
+
+    @Test
+    void criteriaBindsUuidStringAndCollectionAsParameters() {
+        UUID id = UUID.randomUUID();
+        Map<String, Object> map = Map.of(
+                "id", id,
+                "name", "John",
+                "status", List.of("active", "pending"));
+
+        Criteria criteria = QueryHelper.criteria(map);
+        String sql = QueryFragment.Condition.of(criteria).toSql();
+
+        // The dynamically-built SQL references bound parameters, never the raw values.
+        assertThat(sql).contains("id = :").contains("name LIKE :").contains("status IN (:");
+        assertThat(sql).doesNotContain(id.toString());
+        assertThat(sql).doesNotContain("John");
+        assertThat(sql).doesNotContain("active");
+        assertThat(sql).doesNotContain("pending");
+    }
+
+    @Test
+    void criteriaDoesNotConcatenateMaliciousUserInput() {
+        String malicious = "'; DROP TABLE users; --";
+        Map<String, Object> map = Map.of("name", malicious);
+
+        Criteria criteria = QueryHelper.criteria(map);
+        String sql = QueryFragment.Condition.of(criteria).toSql();
+
+        assertThat(sql).contains("name LIKE :");
+        assertThat(sql).doesNotContain(malicious);
+    }
+
+    @Test
+    void criteriaFromObjectWithSkipKeysExcludesSkippedAndNullFields() {
+        SampleEntity entity = new SampleEntity();
+        entity.setName("Bob");
+        entity.setCode(UUID.randomUUID());
+
+        Criteria criteria = QueryHelper.criteria(entity, Set.of("search"));
+        String sql = QueryFragment.Condition.of(criteria).toSql();
+
+        // name and code participate; the skip-key "search" and null "extend" are excluded.
+        assertThat(sql).contains("name LIKE :").contains("code = :");
+        assertThat(sql).doesNotContain("search");
+        assertThat(sql).doesNotContain("extend");
+    }
+
+    @Table("sample_entity")
+    static class SampleEntity {
+        private UUID code;
+        private String name;
+        private String search;
+
+        public UUID getCode() {
+            return code;
+        }
+
+        public void setCode(UUID code) {
+            this.code = code;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getSearch() {
+            return search;
+        }
+
+        public void setSearch(String search) {
+            this.search = search;
+        }
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/query/QueryJsonHelperTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/query/QueryJsonHelperTest.java
@@ -1,0 +1,108 @@
+package com.plate.boot.commons.query;
+
+import com.plate.boot.commons.exception.QueryException;
+import com.plate.boot.commons.utils.DatabaseUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.r2dbc.convert.R2dbcConverter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link QueryJsonHelper} (no Spring / container required).
+ * Focus: JSON sort-property transformation and JSON-path condition building,
+ * including escaping of JSON keys and parameter binding (no value concatenation).
+ */
+class QueryJsonHelperTest {
+
+    private static R2dbcConverter savedConverter;
+
+    @BeforeEach
+    void setUpConverter() {
+        savedConverter = DatabaseUtils.R2DBC_CONVERTER;
+        R2dbcConverter stub = mock(R2dbcConverter.class);
+        when(stub.writeValue(any(), any(org.springframework.data.core.TypeInformation.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        DatabaseUtils.R2DBC_CONVERTER = stub;
+    }
+
+    @AfterEach
+    void tearDownConverter() {
+        DatabaseUtils.R2DBC_CONVERTER = savedConverter;
+    }
+
+
+    @Test
+    void transformSortForJsonNullReturnsUnsorted() {
+        assertThat(QueryJsonHelper.transformSortForJson(null)).isEqualTo(Sort.unsorted());
+    }
+
+    @Test
+    void transformSortForJsonEmptyReturnsUnsorted() {
+        assertThat(QueryJsonHelper.transformSortForJson(Sort.unsorted())).isEqualTo(Sort.unsorted());
+    }
+
+    @Test
+    void transformSortForJsonConvertsCamelToSnakeCase() {
+        Sort result = QueryJsonHelper.transformSortForJson(Sort.by("userName").ascending());
+
+        assertThat(result.get().findFirst().orElseThrow().getProperty()).isEqualTo("user_name");
+    }
+
+    @Test
+    void transformSortForJsonBuildsJsonPathForNestedProperty() {
+        Sort result = QueryJsonHelper.transformSortForJson(Sort.by("extend.name").descending());
+
+        assertThat(result.get().findFirst().orElseThrow().getProperty()).isEqualTo("extend->>'name'");
+        assertThat(result.get().findFirst().orElseThrow().isDescending()).isTrue();
+    }
+
+    @Test
+    void queryJsonBuildsLikeConditionForNestedPath() {
+        Map<String, Object> params = Map.of("extend.usernameLike", "John");
+        QueryFragment.Condition condition = QueryJsonHelper.queryJson(params, null);
+        String sql = condition.toSql();
+
+        assertThat(sql).contains("extend->>'username'");
+        assertThat(sql).contains("LIKE :");
+        assertThat(sql).doesNotContain("John");
+    }
+
+    @Test
+    void queryJsonEscapesSingleQuotesInKey() {
+        Map<String, Object> params = Map.of("extend.user'NameLike", "x");
+        QueryFragment.Condition condition = QueryJsonHelper.queryJson(params, null);
+        String sql = condition.toSql();
+
+        // The apostrophe inside the JSON key must be doubled to avoid breaking SQL.
+        assertThat(sql).contains("user''");
+        assertThat(sql).contains("LIKE :");
+    }
+
+    @Test
+    void queryJsonThrowsForSingleSegmentPath() {
+        Map<String, Object> params = Map.of("invalid", "value");
+
+        assertThatThrownBy(() -> QueryJsonHelper.queryJson(params, null))
+                .isInstanceOf(QueryException.class);
+    }
+
+    @Test
+    void queryJsonWithPrefixQualifiesColumn() {
+        Map<String, Object> params = Map.of("extend.ageGt", 18);
+        QueryFragment.Condition condition = QueryJsonHelper.queryJson(params, "e");
+        String sql = condition.toSql();
+
+        assertThat(sql).contains("e.extend->>'age'");
+        assertThat(sql).contains(">");
+        assertThat(sql).doesNotContain("18");
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/utils/BeanUtilsTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/utils/BeanUtilsTest.java
@@ -1,0 +1,326 @@
+package com.plate.boot.commons.utils;
+
+import com.plate.boot.commons.exception.JsonPointerException;
+import com.plate.boot.commons.exception.RestServerException;
+import com.plate.boot.security.core.UserAuditor;
+import com.plate.boot.security.core.UserAuditorAware;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BeanUtils} (no Spring / container required).
+ * Only the pure helpers are exercised; {@code serializeUserAuditor} is tested with a
+ * mocked {@link UserAuditorAware} for the auditor-resolution branch.
+ */
+class BeanUtilsTest {
+
+    private static JsonMapper savedMapper;
+    private static UserAuditorAware savedAuditorAware;
+
+    @BeforeAll
+    static void setUp() {
+        savedMapper = ContextUtils.OBJECT_MAPPER;
+        ContextUtils.OBJECT_MAPPER = JsonMapper.builder().build();
+        savedAuditorAware = BeanUtils.USER_AUDITOR_AWARE;
+    }
+
+    @AfterAll
+    static void tearDown() {
+        ContextUtils.OBJECT_MAPPER = savedMapper;
+        BeanUtils.USER_AUDITOR_AWARE = savedAuditorAware;
+    }
+
+    @Test
+    void objectToBytesRoundTripsViaMapper() throws Exception {
+        Person person = new Person("Alice", 30, "Alice A");
+        byte[] bytes = BeanUtils.objectToBytes(person);
+
+        assertThat(bytes).isNotEmpty();
+        Person back = ContextUtils.OBJECT_MAPPER.readValue(bytes, Person.class);
+        assertThat(back).isEqualTo(person);
+    }
+
+    @Test
+    void beanToMapIncludesAllProperties() {
+        Person person = new Person("Alice", 30, "Alice A");
+
+        Map<String, Object> map = BeanUtils.beanToMap(person);
+
+        assertThat(map).containsEntry("name", "Alice").containsEntry("age", 30);
+    }
+
+    @Test
+    void beanToMapConvertsKeysToSnakeCase() {
+        Person person = new Person("Alice", 30, "Alice A");
+
+        Map<String, Object> map = BeanUtils.beanToMap(person, true, false);
+
+        assertThat(map).containsKey("full_name");
+    }
+
+    @Test
+    void beanToMapIgnoresNullValuesWhenRequested() {
+        Person person = new Person("Alice", null, null);
+
+        Map<String, Object> map = BeanUtils.beanToMap(person, false, true);
+
+        assertThat(map).containsKey("name").doesNotContainKey("age").doesNotContainKey("fullName");
+    }
+
+    @Test
+    void beanToMapReturnsNullForNullBean() {
+        assertThat(BeanUtils.beanToMap(null)).isNull();
+    }
+
+    @Test
+    void copyPropertiesIntoTargetClass() {
+        Person person = new Person("Bob", 25, "Bob B");
+
+        PersonDto dto = BeanUtils.copyProperties(person, PersonDto.class);
+
+        assertThat(dto.getName()).isEqualTo("Bob");
+        assertThat(dto.getAge()).isEqualTo(25);
+        assertThat(dto.getFullName()).isEqualTo("Bob B");
+    }
+
+    @Test
+    void copyPropertiesIntoTargetObject() {
+        Person person = new Person("Bob", 25, "Bob B");
+        PersonDto dto = new PersonDto();
+
+        BeanUtils.copyProperties(person, dto);
+
+        assertThat(dto.getName()).isEqualTo("Bob");
+        assertThat(dto.getAge()).isEqualTo(25);
+    }
+
+    @Test
+    void copyPropertiesIgnoresNullSourceValues() {
+        Person person = new Person(null, null, null);
+        PersonDto dto = new PersonDto();
+        dto.setName("Keep");
+        dto.setAge(99);
+
+        BeanUtils.copyProperties(person, dto, true);
+
+        assertThat(dto.getName()).isEqualTo("Keep");
+        assertThat(dto.getAge()).isEqualTo(99);
+    }
+
+    @Test
+    void cacheKeyForBeanContainsPropertyEntries() {
+        Person person = new Person("Alice", 30, "Alice A");
+
+        String key = BeanUtils.cacheKey(person);
+
+        assertThat(key).contains("name=Alice").contains("age=30");
+    }
+
+    @Test
+    void cacheKeyForPageableContainsPageAndSort() {
+        String key = BeanUtils.cacheKey(PageRequest.of(0, 10, Sort.by("name").ascending()));
+
+        assertThat(key).contains("0_10").contains("name_ASC");
+    }
+
+    @Test
+    void jsonPathToBeanExtractsNestedScalarValue() {
+        var node = ContextUtils.OBJECT_MAPPER.createObjectNode()
+                .set("user", ContextUtils.OBJECT_MAPPER.createObjectNode().put("name", "John"));
+
+        // JSON Pointer expressions must start with '/'.
+        String name = BeanUtils.jsonPathToBean(node, "/user/name", String.class);
+
+        assertThat(name).isEqualTo("John");
+    }
+
+    @Test
+    void jsonPathToBeanExtractsNestedObject() {
+        var node = ContextUtils.OBJECT_MAPPER.createObjectNode()
+                .set("user", ContextUtils.OBJECT_MAPPER.createObjectNode().put("name", "John"));
+
+        UserName user = BeanUtils.jsonPathToBean(node, "/user", UserName.class);
+
+        assertThat(user.name()).isEqualTo("John");
+    }
+
+    @Test
+    void jsonPathToBeanThrowsForMissingPath() {
+        var node = ContextUtils.OBJECT_MAPPER.createObjectNode().put("name", "John");
+
+        assertThatThrownBy(() -> BeanUtils.jsonPathToBean(node, "/user", String.class))
+                .isInstanceOf(JsonPointerException.class);
+    }
+
+    @Test
+    void serializeUserAuditorResolvesAuditorField() {
+        UserAuditorAware aware = mock(UserAuditorAware.class);
+        UUID code = UUID.randomUUID();
+        when(aware.loadByCode(code)).thenReturn(reactor.core.publisher.Mono.just(UserAuditor.of(code, "Resolved")));
+        BeanUtils.USER_AUDITOR_AWARE = aware;
+
+        AuditedBean bean = new AuditedBean();
+        bean.setCreatedBy(UserAuditor.withCode(code));
+
+        BeanUtils.serializeUserAuditor(bean).block();
+
+        assertThat(bean.getCreatedBy().name()).isEqualTo("Resolved");
+    }
+
+    @Test
+    void serializeUserAuditorReturnsObjectWhenNoAuditorField() {
+        PlainBean bean = new PlainBean();
+        bean.setValue("hi");
+
+        PlainBean result = BeanUtils.serializeUserAuditor(bean).block();
+
+        assertThat(result).isSameAs(bean);
+        assertThat(result.getValue()).isEqualTo("hi");
+    }
+
+    // ---- test fixtures -----------------------------------------------------
+
+    record UserName(String name) {
+    }
+
+    static class Person {
+        private String name;
+        private Integer age;
+        private String fullName;
+
+        Person() {
+        }
+
+        Person(String name, Integer age, String fullName) {
+            this.name = name;
+            this.age = age;
+            this.fullName = fullName;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+
+        public String getFullName() {
+            return fullName;
+        }
+
+        public void setFullName(String fullName) {
+            this.fullName = fullName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Person p)) {
+                return false;
+            }
+            return java.util.Objects.equals(name, p.name)
+                    && java.util.Objects.equals(age, p.age)
+                    && java.util.Objects.equals(fullName, p.fullName);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(name, age, fullName);
+        }
+    }
+
+    static class PersonDto {
+        private String name;
+        private Integer age;
+        private String fullName;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+
+        public String getFullName() {
+            return fullName;
+        }
+
+        public void setFullName(String fullName) {
+            this.fullName = fullName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof PersonDto p)) {
+                return false;
+            }
+            return java.util.Objects.equals(name, p.name)
+                    && java.util.Objects.equals(age, p.age)
+                    && java.util.Objects.equals(fullName, p.fullName);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(name, age, fullName);
+        }
+    }
+
+    static class PlainBean {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static class AuditedBean {
+        private UserAuditor createdBy;
+
+        public UserAuditor getCreatedBy() {
+            return createdBy;
+        }
+
+        public void setCreatedBy(UserAuditor createdBy) {
+            this.createdBy = createdBy;
+        }
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/utils/ContextUtilsTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/utils/ContextUtilsTest.java
@@ -1,0 +1,173 @@
+package com.plate.boot.commons.utils;
+
+import com.plate.boot.commons.base.AbstractEvent;
+import com.plate.boot.security.SecurityDetails;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the pure parts of {@link ContextUtils} (no Spring / container required).
+ * <p>
+ * {@code securityDetails()} and {@code eventPublisher(...)} are reactive/static and are exercised
+ * with mocked collaborators. The reactive security-context test uses
+ * {@link ReactiveSecurityContextHolder#withSecurityContext} without any live server.
+ */
+class ContextUtilsTest {
+
+    @Test
+    void nextIdReturnsUuidV7() {
+        UUID id = ContextUtils.nextId();
+
+        assertThat(id).isNotNull();
+        assertThat(id.version()).isEqualTo(7);
+        assertThat(id.variant()).isEqualTo(2);
+    }
+
+    @Test
+    void defaultUuidCodeIsAllZeros() {
+        assertThat(ContextUtils.DEFAULT_UUID_CODE).isEqualTo(new UUID(0L, 0L));
+    }
+
+    @Test
+    void ruleAdministratorsConstantHasExpectedValue() {
+        assertThat(ContextUtils.RULE_ADMINISTRATORS).isEqualTo("ROLE_SYSTEM_ADMINISTRATORS");
+    }
+
+    @Test
+    void encodeToSha256IsDeterministicAndBase64() throws Exception {
+        String input = "test";
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+        String expected = Base64.getEncoder().encodeToString(hash);
+
+        assertThat(ContextUtils.encodeToSHA256(input)).isEqualTo(expected);
+        assertThat(ContextUtils.encodeToSHA256(null)).isNull();
+    }
+
+    @Test
+    void createDelegatingPasswordEncoderEncodesAndMatches() {
+        PasswordEncoder encoder = ContextUtils.createDelegatingPasswordEncoder("bcrypt");
+        String encoded = encoder.encode("secret");
+
+        assertThat(encoded).startsWith("{bcrypt}");
+        assertThat(encoder.matches("secret", encoded)).isTrue();
+        assertThat(encoder.matches("wrong", encoded)).isFalse();
+    }
+
+    @Test
+    void createDelegatingPasswordEncoderNoopPrefix() {
+        PasswordEncoder encoder = ContextUtils.createDelegatingPasswordEncoder("noop");
+
+        assertThat(encoder.encode("secret")).isEqualTo("{noop}secret");
+        assertThat(encoder.matches("secret", "{noop}secret")).isTrue();
+    }
+
+    @Test
+    void createDelegatingPasswordEncoderDefaultsToBcryptForNullId() {
+        PasswordEncoder encoder = ContextUtils.createDelegatingPasswordEncoder(null);
+
+        assertThat(encoder.matches("secret", encoder.encode("secret"))).isTrue();
+    }
+
+    @Test
+    void getClientIpAddressReturnsNullForNullRequest() {
+        assertThat(ContextUtils.getClientIpAddress(null)).isNull();
+    }
+
+    @Test
+    void getClientIpAddressReadsXForwardedFor() {
+        ServerHttpRequest req = mock(ServerHttpRequest.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-Forwarded-For", "8.8.8.8");
+        when(req.getHeaders()).thenReturn(headers);
+        when(req.getRemoteAddress()).thenReturn(null);
+
+        assertThat(ContextUtils.getClientIpAddress(req)).isEqualTo("8.8.8.8");
+    }
+
+    @Test
+    void getClientIpAddressFallsBackToRemoteAddressWhenHeaderPrivate() throws Exception {
+        ServerHttpRequest req = mock(ServerHttpRequest.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-Forwarded-For", "10.0.0.1");
+        when(req.getHeaders()).thenReturn(headers);
+        when(req.getRemoteAddress()).thenReturn(
+                new InetSocketAddress(InetAddress.getByName("8.8.8.8"), 1234));
+
+        assertThat(ContextUtils.getClientIpAddress(req)).isEqualTo("8.8.8.8");
+    }
+
+    @Test
+    void securityDetailsIsEmptyWithoutContext() {
+        assertThat(ContextUtils.securityDetails().block()).isNull();
+    }
+
+    @Test
+    void securityDetailsIsEmptyWhenPrincipalIsNotSecurityDetails() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn("not-an-auditor");
+
+        SecurityDetails result = ContextUtils.securityDetails()
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                        reactor.core.publisher.Mono.just(new SecurityContextImpl(auth))))
+                .block();
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void securityDetailsReturnsPrincipalWhenItIsSecurityDetails() {
+        SecurityDetails details = new SecurityDetails(List.of(), Map.of("username", "admin"), "username");
+        details.setCode(UUID.randomUUID());
+
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(details);
+
+        SecurityDetails result = ContextUtils.securityDetails()
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                        reactor.core.publisher.Mono.just(new SecurityContextImpl(auth))))
+                .block();
+
+        assertThat(result).isSameAs(details);
+    }
+
+    @Test
+    void eventPublisherPublishesThroughStaticPublisher() {
+        var publisher = mock(org.springframework.context.ApplicationEventPublisher.class);
+        var saved = ContextUtils.APPLICATION_EVENT_PUBLISHER;
+        ContextUtils.APPLICATION_EVENT_PUBLISHER = publisher;
+        try {
+            TestEvent event = new TestEvent("entity");
+            ContextUtils.eventPublisher(event);
+
+            verify(publisher).publishEvent(event);
+        } finally {
+            ContextUtils.APPLICATION_EVENT_PUBLISHER = saved;
+        }
+    }
+
+    static class TestEvent extends AbstractEvent<String> {
+        TestEvent(String entity) {
+            super(entity, Kind.INSERT);
+        }
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/commons/utils/DatabaseUtilsTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/commons/utils/DatabaseUtilsTest.java
@@ -1,0 +1,106 @@
+package com.plate.boot.commons.utils;
+
+import com.plate.boot.commons.ProgressEvent;
+import com.plate.boot.commons.exception.RestServerException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pure parts of {@link DatabaseUtils} (no Spring / R2DBC connection required).
+ * <p>
+ * {@code getBeanSize} is exercised with the shared {@link ContextUtils#OBJECT_MAPPER}, and {@code batchEvent}
+ * is a pure reactive operator that needs no database. The SQL-bound methods ({@code query}, {@code count},
+ * {@code count(String, Map)}) rely on the static {@code DATABASE_CLIENT}/{@code ENTITY_TEMPLATE} which are only
+ * populated by a Spring context, so they are covered by the integration tests instead of these unit tests.
+ */
+class DatabaseUtilsTest {
+
+    private static JsonMapper savedMapper;
+
+    @BeforeAll
+    static void setUp() {
+        savedMapper = ContextUtils.OBJECT_MAPPER;
+        ContextUtils.OBJECT_MAPPER = JsonMapper.builder().build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        ContextUtils.OBJECT_MAPPER = savedMapper;
+    }
+
+    @Test
+    void getBeanSizeReturnsZeroForNull() {
+        assertThat(DatabaseUtils.getBeanSize(null).toBytes()).isZero();
+    }
+
+    @Test
+    void getBeanSizeReturnsPositiveForSerializableObject() {
+        assertThat(DatabaseUtils.getBeanSize(Map.of("a", 1)).toBytes()).isPositive();
+    }
+
+    @Test
+    void batchEventEmitsStartItemsAndEnd() {
+        Flux<String> items = Flux.just("a", "b", "c");
+
+        StepVerifier.create(DatabaseUtils.batchEvent(items, req -> Mono.just("ok")))
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isZero();
+                    assertThat(e.getMessage()).contains("Starting");
+                })
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isEqualTo(1);
+                    assertThat(e.getIsOk()).isTrue();
+                    assertThat(e.getRes()).isEqualTo("ok");
+                })
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isEqualTo(2);
+                    assertThat(e.getRes()).isEqualTo("ok");
+                })
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isEqualTo(3);
+                    assertThat(e.getRes()).isEqualTo("ok");
+                })
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isEqualTo(100);
+                    assertThat(e.getMessage()).contains("completed");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void batchEventReportsErrorPerItem() {
+        Flux<String> items = Flux.just("a");
+
+        StepVerifier.create(DatabaseUtils.batchEvent(items,
+                req -> Mono.error(new RuntimeException("boom", new IllegalStateException("root cause")))))
+                .assertNext(e -> assertThat(e.getProcessed()).isZero())
+                .assertNext(e -> {
+                    assertThat(e.getProcessed()).isEqualTo(1);
+                    assertThat(e.getIsOk()).isFalse();
+                    assertThat(e.getError()).isInstanceOf(RestServerException.class);
+                })
+                .assertNext(e -> assertThat(e.getProcessed()).isEqualTo(100))
+                .verifyComplete();
+    }
+
+    @Test
+    void progressEventHelpersCompileAndChain() {
+        ProgressEvent event = ProgressEvent.of(1L, "req")
+                .withResult("done", "res");
+        assertThat(event.getIsOk()).isTrue();
+        assertThat(event.getRes()).isEqualTo("res");
+
+        ProgressEvent failed = ProgressEvent.of(2L, "req").withError("bad", new RestServerException("x", new RuntimeException()));
+        assertThat(failed.getIsOk()).isFalse();
+        assertThat(failed.getError()).isNotNull();
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/relational/dictionaries/DictionariesIntegrationTests.java
+++ b/boot/platform/src/test/java/com/plate/boot/relational/dictionaries/DictionariesIntegrationTests.java
@@ -1,0 +1,45 @@
+package com.plate.boot.relational.dictionaries;
+
+import com.plate.boot.AbstractIntegrationTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DictionariesController}.
+ * <p>
+ * Verifies the routing fix: the controller no longer hardcodes the {@code /rel} prefix in its
+ * {@code @RequestMapping}, so endpoints are exposed once under the framework-applied prefix
+ * (e.g. {@code /rel/dictionaries}) and NOT under a doubled {@code /rel/rel/dictionaries} path.
+ */
+@DisplayName("Dictionaries")
+class DictionariesIntegrationTests extends AbstractIntegrationTests {
+
+    private String adminToken;
+
+    @BeforeEach
+    void setUp() {
+        adminToken = loginAndGetToken(ADMIN_USERNAME, ADMIN_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("should expose dictionaries under the single path prefix")
+    void shouldExposeDictionariesUnderSinglePrefix() {
+        webTestClient.get().uri(relPrefix() + "/dictionaries")
+                .headers(headers -> headers.setBearerAuth(adminToken))
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    @DisplayName("should not expose dictionaries under a doubled path prefix")
+    void shouldNotExposeDictionariesUnderDoubledPrefix() {
+        webTestClient.get().uri(relPrefix() + "/rel/dictionaries")
+                .headers(headers -> headers.setBearerAuth(adminToken))
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/security/AuthenticationTokenTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/security/AuthenticationTokenTest.java
@@ -1,0 +1,54 @@
+package com.plate.boot.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.WebSession;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AuthenticationToken}, focusing on the {@code build(WebSession, Object)}
+ * factory which must tolerate nullable session timestamps (last access time / max idle time)
+ * instead of throwing a {@link NullPointerException}.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthenticationTokenTest {
+
+    @Mock
+    private WebSession session;
+
+    @Test
+    void buildShouldNotThrowWhenSessionTimestampsAreNull() {
+        when(session.getId()).thenReturn("session-123");
+        when(session.getLastAccessTime()).thenReturn(null);
+        when(session.getMaxIdleTime()).thenReturn(null);
+
+        AuthenticationToken token = AuthenticationToken.build(session, "principal");
+
+        assertThat(token).isNotNull();
+        assertThat(token.token()).isEqualTo("session-123");
+        assertThat(token.lastAccessTime()).isNotNull();
+        assertThat(token.expires()).isEqualTo(1800L);
+        assertThat(token.details()).isEqualTo("principal");
+    }
+
+    @Test
+    void buildShouldUseProvidedTimestampsWhenPresent() {
+        Instant lastAccess = Instant.parse("2026-01-01T00:00:00Z");
+        when(session.getId()).thenReturn("session-456");
+        when(session.getLastAccessTime()).thenReturn(lastAccess);
+        when(session.getMaxIdleTime()).thenReturn(Duration.ofSeconds(600));
+
+        AuthenticationToken token = AuthenticationToken.build(session, "principal");
+
+        assertThat(token.token()).isEqualTo("session-456");
+        assertThat(token.lastAccessTime()).isEqualTo(lastAccess.getEpochSecond());
+        assertThat(token.expires()).isEqualTo(600L);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/security/captcha/CaptchaRepositoryTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/security/captcha/CaptchaRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.plate.boot.security.captcha;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CaptchaRepository#createCaptchaToken()}, verifying that the generated
+ * captcha code is randomly produced (no longer the previously hardcoded {@code "54321"}) and that
+ * successive codes vary.
+ */
+class CaptchaRepositoryTest {
+
+    @Test
+    void createCaptchaTokenShouldGenerateRandomFiveDigitCodeNotHardcoded() {
+        CaptchaRepository repository = new CaptchaRepository();
+
+        CaptchaToken token = repository.createCaptchaToken();
+
+        assertThat(token.captcha()).isNotEqualTo("54321");
+        assertThat(token.captcha()).matches("\\d{5}");
+    }
+
+    @Test
+    void createCaptchaTokenShouldVaryAcrossCalls() {
+        CaptchaRepository repository = new CaptchaRepository();
+
+        Set<String> codes = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            codes.add(repository.createCaptchaToken().captcha());
+        }
+
+        assertThat(codes.size()).isGreaterThan(1);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/security/captcha/CaptchaTokenTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/security/captcha/CaptchaTokenTest.java
@@ -1,0 +1,34 @@
+package com.plate.boot.security.captcha;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link CaptchaToken} validation behaviour.
+ */
+class CaptchaTokenTest {
+
+    @Test
+    void validateShouldReturnTrueForMatchingCodeCaseInsensitive() {
+        CaptchaToken token = CaptchaToken.of("X-CAPTCHA-TOKEN", "_captcha", "Ab12");
+
+        assertThat(token.validate("ab12")).isTrue();
+    }
+
+    @Test
+    void validateShouldReturnFalseForMismatchedCode() {
+        CaptchaToken token = CaptchaToken.of("X-CAPTCHA-TOKEN", "_captcha", "12345");
+
+        assertThat(token.validate("00000")).isFalse();
+    }
+
+    @Test
+    void validateShouldThrowForNullCode() {
+        CaptchaToken token = CaptchaToken.of("X-CAPTCHA-TOKEN", "_captcha", "12345");
+
+        assertThatThrownBy(() -> token.validate(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/boot/platform/src/test/java/com/plate/boot/security/core/user/authority/UserAuthoritiesServiceTest.java
+++ b/boot/platform/src/test/java/com/plate/boot/security/core/user/authority/UserAuthoritiesServiceTest.java
@@ -1,0 +1,51 @@
+package com.plate.boot.security.core.user.authority;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link UserAuthoritiesService#delete(UserAuthorityReq)}.
+ * <p>
+ * Verifies the delete path locates the row by the {@code id} supplied by the controller
+ * (previously it mistakenly used {@code code}, producing a silent no-op), and that the
+ * repository delete is invoked with the resolved entity.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserAuthoritiesServiceTest {
+
+    @Mock
+    private UserAuthoritiesRepository repository;
+
+    @InjectMocks
+    private UserAuthoritiesService service;
+
+    @Test
+    void deleteShouldLocateByProvidedIdNotByCode() {
+        UserAuthority entity = new UserAuthority();
+        entity.setId(42);
+
+        UserAuthorityReq request = new UserAuthorityReq();
+        request.setId(42);
+        // code intentionally left null, mirroring a normal delete request shape
+
+        when(repository.findById(42)).thenReturn(Mono.just(entity));
+        when(repository.delete(any(UserAuthority.class))).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.delete(request)).verifyComplete();
+
+        verify(repository).findById(42);
+        verify(repository, never()).findByCode(any());
+        verify(repository).delete(entity);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes 4 Critical defects found during code review and adds backend unit tests to improve coverage and stability. All changes preserve existing business logic.

## Bug fixes (minimal, logic unchanged)
- **fix(security): hardcoded captcha bypass + enable CaptchaFilter** (`CaptchaRepository`/`CaptchaFilter`)
  - Replaced the hardcoded `"54321"` captcha with a 5-digit `ThreadLocalRandom` code.
  - Enabled the previously commented-out `CaptchaFilter @Component` so `/oauth2/token` is actually captcha-protected.
- **fix(security): AuthenticationToken.build NPE** (`AuthenticationToken`)
  - `getLastAccessTime()` and `getMaxIdleTime()` may be null in some session implementations; added null-safe fallbacks (current time / 1800s).
- **fix(relational): duplicate dictionary path prefix** (`DictionariesController`)
  - Changed `@RequestMapping` from `"/rel/dictionaries"` to `"/dictionaries"` to avoid the framework-applied `/rel` prefix producing `/rel/rel/dictionaries` (404).
- **fix(security): silent failure in user authority deletion** (`UserAuthoritiesService`)
  - `delete` now resolves the row by `request.getId()` (consistent with the group authority service) instead of `findByCode`, which was a no-op when the controller had already validated the id.

## Tests added
- `test(commons)`: unit tests for base/converters/exception/query/utils packages (~116 cases).
- `test(security)`: captcha randomness and case-insensitive validation, AuthenticationToken null-safe build, UserAuthoritiesService delete behavior.
- `test`: dictionary endpoint integration test (`/rel/dictionaries` 200, `/rel/rel/dictionaries` 404) and `ApplicationContextTests` verifying `CaptchaFilter` is registered as a bean.

## Verification
- Full suite `./gradlew :platform:test` (Testcontainers + Docker) passes: **152 tests, 0 failures**.
- Per AGENTS.md §0, the repo has no JaCoCo/coverage gate; "100% tests" means the full suite passes, no coverage tool added.

## Notes
- This environment cannot interactively provide the GPG private-key passphrase, so commits are created unsigned (repo has `commit.gpgsign=true`; rebase/cherry-pick locally to add verified signatures if needed).
- Rebased onto latest `origin/dev` (`567ebf1` adds `.gitattributes` for line-ending normalization).